### PR TITLE
Polish UI/UX: settings & detail screens, string resources, time picker fixes

### DIFF
--- a/.github/workflows/build_bundle.yml
+++ b/.github/workflows/build_bundle.yml
@@ -12,7 +12,7 @@ on:
           - 'PublicTrack'
           - 'beta'
           - 'production'
-        default: 'PublicTrack'
+        default: 'beta'
       branch:
         description: 'Branch to build (e.g., main)'
         required: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,158 @@
+name: Deploy to Play Store
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, closed]
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Play Store track'
+        required: true
+        type: choice
+        options:
+          - beta
+          - internal
+          - production
+        default: beta
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    if: github.event_name == 'workflow_dispatch' || github.event.action != 'closed' || github.event.pull_request.merged == true
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4.2.2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', '**/gradle/libs.versions.toml', '**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run unit tests
+        run: ./gradlew test
+
+  deploy:
+    if: (github.event_name == 'pull_request' && github.event.pull_request.merged) || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4.2.2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', '**/gradle/libs.versions.toml', '**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: mkdir -p keystore_details && echo "$KEYSTORE_BASE64" | base64 -d > keystore_details/release.keystore
+
+      - name: Fetch tags
+        run: git fetch --tags origin
+
+      - name: Bump version
+        id: bump
+        run: |
+          code=$(grep 'versionCode = ' app/build.gradle.kts | sed 's/.*versionCode = \([0-9]*\).*/\1/')
+          name=$(grep 'versionName = ' app/build.gradle.kts | sed 's/.*versionName = "\(.*\)".*/\1/')
+          new_code=$((code + 1))
+          IFS='.' read -ra PARTS <<< "$name"
+          major="${PARTS[0]}"
+          minor="${PARTS[1]}"
+          new_minor=$((minor + 1))
+          new_name="${major}.$(printf "%02d" $new_minor)"
+          sed -i "s/versionName = \".*\"/versionName = \"$new_name\"/" app/build.gradle.kts
+          sed -i "s/versionCode = .*/versionCode = $new_code/" app/build.gradle.kts
+          echo "new_version_code=$new_code" >> "$GITHUB_OUTPUT"
+          echo "new_version_name=$new_name" >> "$GITHUB_OUTPUT"
+
+      - name: Build signed release AAB
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/keystore_details/release.keystore
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: ./gradlew bundleRelease
+
+      - name: Rename AAB file
+        run: |
+          mv app/build/outputs/bundle/release/app-release.aab \
+             app/build/outputs/bundle/release/DoTrack-v${{ steps.bump.outputs.new_version_name }}-release.aab
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          prev_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$prev_tag" ]; then
+            notes=$(git log "$prev_tag"..HEAD --oneline --no-merges --format="- %s" 2>/dev/null || true)
+          else
+            notes=$(git log --oneline --no-merges --format="- %s" -20 2>/dev/null || true)
+          fi
+          if [ -z "$notes" ]; then
+            notes="- Bug fixes and improvements"
+          fi
+          mkdir -p /tmp/whatsnew
+          echo "$notes" > /tmp/whatsnew/default
+          echo "notes_file=/tmp/whatsnew/default" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to Google Play
+        uses: r0adkll/upload-google-play@v1.1.3
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.shreyash.dotrack
+          releaseFiles: app/build/outputs/bundle/release/DoTrack-v${{ steps.bump.outputs.new_version_name }}-release.aab
+          track: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.track || 'beta' }}
+          status: completed
+          inAppUpdatePriority: 2
+          whatsNewDirectory: /tmp/whatsnew/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.bump.outputs.new_version_name }}" \
+            --title "v${{ steps.bump.outputs.new_version_name }}" \
+            --notes-file /tmp/whatsnew/default \
+            app/build/outputs/bundle/release/DoTrack-v${{ steps.bump.outputs.new_version_name }}-release.aab
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add app/build.gradle.kts
+          git commit -m "Bump version to ${{ steps.bump.outputs.new_version_name }} (${{ steps.bump.outputs.new_version_code }}) [skip ci]"
+          git push

--- a/app/src/main/java/com/shreyash/dotrack/ReminderWorker.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ReminderWorker.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.shreyash.dotrack.R
 import com.shreyash.dotrack.domain.repository.TaskRepository
 import com.shreyash.dotrack.widget.TaskWidgetUpdater
 import com.shreyash.dotrack.workmanager.TaskRepositoryEntryPoint
@@ -31,19 +32,20 @@ class ReminderWorker(
         ).taskRepository()
     }
 
+    private val CHANNEL_ID = applicationContext.getString(R.string.reminder_channel_id)
+    private val CHANNEL_NAME = applicationContext.getString(R.string.reminder_channel_name)
+    private val CHANNEL_DESCRIPTION = applicationContext.getString(R.string.reminder_channel_desc)
+
     companion object {
         const val KEY_TASK_ID = "taskId"
         const val KEY_TITLE = "title"
-        private const val CHANNEL_ID = "reminder_channel"
-        private const val CHANNEL_NAME = "Task Reminders"
-        private const val CHANNEL_DESCRIPTION = "Notifications for task reminders"
         private const val TAG = "ReminderWorker"
     }
 
     override suspend fun doWork(): Result {
         try {
             val taskId = inputData.getString(KEY_TASK_ID) ?: return Result.failure()
-            val title = inputData.getString(KEY_TITLE) ?: "Task Reminder"
+            val title = inputData.getString(KEY_TITLE) ?: applicationContext.getString(R.string.task_reminder)
 
             withContext(Dispatchers.IO) {
                 try {
@@ -114,7 +116,7 @@ class ReminderWorker(
             applicationContext, CHANNEL_ID
         )
             .setSmallIcon(icon)
-            .setContentTitle("Task Reminder")
+            .setContentTitle(applicationContext.getString(R.string.task_reminder))
             .setContentText(title)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setCategory(NotificationCompat.CATEGORY_REMINDER)

--- a/app/src/main/java/com/shreyash/dotrack/ReminderWorker.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ReminderWorker.kt
@@ -107,15 +107,7 @@ class ReminderWorker(
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
-        // Get the app's icon resource ID
-        val iconResId = applicationContext.resources.getIdentifier(
-            "ic_notification",
-            "drawable",
-            applicationContext.packageName
-        )
-
-        // Use a fallback icon if the app's icon is not found
-        val icon = if (iconResId != 0) iconResId else android.R.drawable.ic_dialog_info
+        val icon = R.drawable.ic_launcher_foreground
 
         // Build the notification
         val notification = NotificationCompat.Builder(

--- a/app/src/main/java/com/shreyash/dotrack/ui/categories/AddEditCategoryScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/categories/AddEditCategoryScreen.kt
@@ -28,8 +28,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.shreyash.dotrack.R
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -43,6 +45,7 @@ fun AddEditCategoryScreen(
     var name by remember { mutableStateOf("") }
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val errorSavingCategoryMessage = stringResource(R.string.error_saving_category)
 
     LaunchedEffect(categoryId) {
         if (categoryId != null) {
@@ -55,12 +58,12 @@ fun AddEditCategoryScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(if (categoryId == null) "Add Category" else "Edit Category") },
+                title = { Text(if (categoryId == null) stringResource(R.string.add_category) else stringResource(R.string.edit_category)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
+                            contentDescription = stringResource(R.string.back)
                         )
                     }
                 }
@@ -79,7 +82,7 @@ fun AddEditCategoryScreen(
                             onCategorySaved()
                         } else {
                             snackbarHostState.showSnackbar(
-                                result.exceptionOrNull()?.message ?: "Error saving category"
+                                result.exceptionOrNull()?.message ?: errorSavingCategoryMessage
                             )
                         }
                     }
@@ -87,7 +90,7 @@ fun AddEditCategoryScreen(
             ) {
                 Icon(
                     imageVector = Icons.Default.Check,
-                    contentDescription = "Save Category"
+                    contentDescription = stringResource(R.string.save_category)
                 )
             }
         },
@@ -102,7 +105,7 @@ fun AddEditCategoryScreen(
             OutlinedTextField(
                 value = name,
                 onValueChange = { name = it },
-                label = { Text("Category Name") },
+                label = { Text(stringResource(R.string.category_name)) },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true
             )

--- a/app/src/main/java/com/shreyash/dotrack/ui/categories/CategoriesScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/categories/CategoriesScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -37,6 +38,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.shreyash.dotrack.R
 import com.shreyash.dotrack.domain.model.Category
 
 @Preview(showBackground = true)
@@ -62,14 +64,14 @@ fun CategoriesScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Categories") }
+                title = { Text(stringResource(R.string.categories)) }
             )
         },
         floatingActionButton = {
             FloatingActionButton(onClick = onAddCategoryClick) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = "Add Category"
+                    contentDescription = stringResource(R.string.add_category)
                 )
             }
         }
@@ -95,7 +97,7 @@ fun CategoriesScreen(
                             .padding(padding),
                         contentAlignment = Alignment.Center
                     ) {
-                        Text("No categories yet. Add one!")
+                        Text(stringResource(R.string.no_categories_yet))
                     }
                 } else {
                     CategoryList(
@@ -113,7 +115,7 @@ fun CategoriesScreen(
                         .padding(padding),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text("Error: ${categoriesState.exceptionOrNull()?.message}")
+                    Text(stringResource(R.string.error_format, categoriesState.exceptionOrNull()?.message ?: ""))
                 }
             }
         }

--- a/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsScreen.kt
@@ -19,17 +19,21 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -42,11 +46,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -70,10 +76,81 @@ fun SettingsScreenPreview() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+private fun SettingsPreviewContent() {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(R.string.settings)) })
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+                )
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    SettingSwitchItem(
+                        title = stringResource(R.string.auto_wallpaper_updates),
+                        subtitle = stringResource(R.string.auto_wallpaper_subtitle),
+                        checked = false,
+                        onCheckedChange = {}
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                    Text(stringResource(R.string.wallpaper_color), style = MaterialTheme.typography.bodyLarge)
+                    Text(stringResource(R.string.wallpaper_color_subtitle), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        WallpaperColorCircle(colorHex = "#1A2980", label = "Primary", onClick = {})
+                        WallpaperColorCircle(colorHex = "#26D0CE", label = "Secondary", onClick = {})
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(stringResource(R.string.task_priority_colors), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, modifier = Modifier.padding(bottom = 8.dp))
+            Card(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f))) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    ColorSettingItem(title = stringResource(R.string.high_priority), subtitle = stringResource(R.string.high_priority_subtitle), colorHex = "#FF4444", onClick = {})
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                    ColorSettingItem(title = stringResource(R.string.medium_priority), subtitle = stringResource(R.string.medium_priority_subtitle), colorHex = "#FFBB33", onClick = {})
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                    ColorSettingItem(title = stringResource(R.string.low_priority), subtitle = stringResource(R.string.low_priority_subtitle), colorHex = "#00C851", onClick = {})
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(stringResource(R.string.notifications), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, modifier = Modifier.padding(bottom = 8.dp))
+            Card(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f))) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    SettingSwitchItem(title = stringResource(R.string.permission), subtitle = stringResource(R.string.enable_notification_permission), checked = false, onCheckedChange = {})
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            OutlinedButton(modifier = Modifier.fillMaxWidth(), onClick = {}, shape = RoundedCornerShape(12.dp)) {
+                Icon(painterResource(id = R.drawable.ic_sync), contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.sync_up))
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
-
 ) {
+    if (LocalInspectionMode.current) {
+        SettingsPreviewContent()
+        return
+    }
+
     // Collect states from ViewModel
     val isAutoWallpaperEnabled by viewModel.autoWallpaperEnabled.collectAsState()
     val currentWallpaperColor by viewModel.wallpaperColor.collectAsState()
@@ -97,11 +174,11 @@ fun SettingsScreen(
         ColorPickerDialog(
             initialColor = viewModel.selectedColor,
             title = when (viewModel.currentColorPickerMode) {
-                ColorPickerMode.WALLPAPER -> "Choose Wallpaper Color"
-                ColorPickerMode.SECONDARY_WALLPAPER -> "Choose Secondary Wallpaper Color"
-                ColorPickerMode.HIGH_PRIORITY -> "Choose High Priority Color"
-                ColorPickerMode.MEDIUM_PRIORITY -> "Choose Medium Priority Color"
-                ColorPickerMode.LOW_PRIORITY -> "Choose Low Priority Color"
+                ColorPickerMode.WALLPAPER -> stringResource(R.string.choose_wallpaper_color)
+                ColorPickerMode.SECONDARY_WALLPAPER -> stringResource(R.string.choose_secondary_wallpaper_color)
+                ColorPickerMode.HIGH_PRIORITY -> stringResource(R.string.choose_high_priority_color)
+                ColorPickerMode.MEDIUM_PRIORITY -> stringResource(R.string.choose_medium_priority_color)
+                ColorPickerMode.LOW_PRIORITY -> stringResource(R.string.choose_low_priority_color)
             },
             onColorSelected = { color ->
                 viewModel.updateSelectedColor(color)
@@ -125,134 +202,155 @@ fun SettingsScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("Settings") })
+            TopAppBar(title = { Text(stringResource(R.string.settings)) })
         }
     ) { padding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp)
         ) {
-            SettingSwitchItem(
-                title = "Auto Wallpaper Updates",
-                subtitle = "Automatically update wallpaper when tasks change",
-                checked = isAutoWallpaperEnabled,
-                onCheckedChange = { viewModel.setAutoWallpaperEnabled(it) }
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Current wallpaper color preview
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 12.dp)
+            // Wallpaper Section
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+                )
             ) {
-                Column(
-                    modifier = Modifier.weight(1f)
-                ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    SettingSwitchItem(
+                        title = stringResource(R.string.auto_wallpaper_updates),
+                        subtitle = stringResource(R.string.auto_wallpaper_subtitle),
+                        checked = isAutoWallpaperEnabled,
+                        onCheckedChange = { viewModel.setAutoWallpaperEnabled(it) }
+                    )
+
+                    HorizontalDivider(
+                        modifier = Modifier.padding(vertical = 8.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+
                     Text(
-                        text = "Wallpaper Color",
+                        text = stringResource(R.string.wallpaper_color),
                         style = MaterialTheme.typography.bodyLarge
                     )
                     Text(
-                        text = "Choose background color for wallpaper",
+                        text = stringResource(R.string.wallpaper_color_subtitle),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        WallpaperColorCircle(
+                            colorHex = currentWallpaperColor,
+                            label = "Primary",
+                            onClick = { viewModel.showWallpaperColorPicker() }
+                        )
+                        WallpaperColorCircle(
+                            colorHex = secondaryWallpaperColor,
+                            label = "Secondary",
+                            onClick = { viewModel.showSecondaryWallpaperColorPicker() }
+                        )
+                    }
                 }
-
-                // Color preview
-                Box(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clip(CircleShape)
-                        .clickable { viewModel.showWallpaperColorPicker() }
-                        .background(Color(android.graphics.Color.parseColor(currentWallpaperColor)))
-                        .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape)
-                )
-
-                Spacer(modifier = Modifier.width(8.dp))
-                Box(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clip(CircleShape)
-                        .clickable { viewModel.showSecondaryWallpaperColorPicker() }
-                        .background(Color(android.graphics.Color.parseColor(secondaryWallpaperColor)))
-                        .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape)
-                )
-
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
             // Priority Colors Section
             Text(
-                text = "Task Priority Colors",
+                text = stringResource(R.string.task_priority_colors),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(vertical = 8.dp)
+                modifier = Modifier.padding(bottom = 8.dp)
             )
 
-            // High Priority Color
-            val currentHighPriorityColor by viewModel.highPriorityColor.collectAsState()
-            ColorSettingItem(
-                title = "High Priority",
-                subtitle = "Color for high priority tasks",
-                colorHex = currentHighPriorityColor,
-                onClick = { viewModel.showPriorityColorPicker(Priority.HIGH) }
-            )
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+                )
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    val currentHighPriorityColor by viewModel.highPriorityColor.collectAsState()
+                    ColorSettingItem(
+                        title = stringResource(R.string.high_priority),
+                        subtitle = stringResource(R.string.high_priority_subtitle),
+                        colorHex = currentHighPriorityColor,
+                        onClick = { viewModel.showPriorityColorPicker(Priority.HIGH) }
+                    )
 
-            // Medium Priority Color
-            val currentMediumPriorityColor by viewModel.mediumPriorityColor.collectAsState()
-            ColorSettingItem(
-                title = "Medium Priority",
-                subtitle = "Color for medium priority tasks",
-                colorHex = currentMediumPriorityColor,
-                onClick = { viewModel.showPriorityColorPicker(Priority.MEDIUM) }
-            )
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
 
-            // Low Priority Color
-            val currentLowPriorityColor by viewModel.lowPriorityColor.collectAsState()
-            ColorSettingItem(
-                title = "Low Priority",
-                subtitle = "Color for low priority tasks",
-                colorHex = currentLowPriorityColor,
-                onClick = { viewModel.showPriorityColorPicker(Priority.LOW) }
-            )
+                    val currentMediumPriorityColor by viewModel.mediumPriorityColor.collectAsState()
+                    ColorSettingItem(
+                        title = stringResource(R.string.medium_priority),
+                        subtitle = stringResource(R.string.medium_priority_subtitle),
+                        colorHex = currentMediumPriorityColor,
+                        onClick = { viewModel.showPriorityColorPicker(Priority.MEDIUM) }
+                    )
 
-            Spacer(modifier = Modifier.height(16.dp))
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+
+                    val currentLowPriorityColor by viewModel.lowPriorityColor.collectAsState()
+                    ColorSettingItem(
+                        title = stringResource(R.string.low_priority),
+                        subtitle = stringResource(R.string.low_priority_subtitle),
+                        colorHex = currentLowPriorityColor,
+                        onClick = { viewModel.showPriorityColorPicker(Priority.LOW) }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
 
             // Notifications Section
             Text(
-                text = "Notifications",
+                text = stringResource(R.string.notifications),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(vertical = 8.dp)
+                modifier = Modifier.padding(bottom = 8.dp)
             )
 
-            SettingSwitchItem(
-                title = "Permission",
-                subtitle = "Enable notifications permissions",
-                checked = isNotificationEnabled,
-                onCheckedChange = {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        if (!isNotificationEnabled) {
-                            // Show permission dialog
-                            showPermissionDialog = true
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+                )
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    SettingSwitchItem(
+                        title = stringResource(R.string.permission),
+                        subtitle = stringResource(R.string.enable_notification_permission),
+                        checked = isNotificationEnabled,
+                        onCheckedChange = {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                if (!isNotificationEnabled) {
+                                    showPermissionDialog = true
+                                }
+                            }
                         }
-                    }
+                    )
                 }
-            )
+            }
 
             // Permission request dialog
             if (showPermissionDialog) {
                 AlertDialog(
                     onDismissRequest = { showPermissionDialog = false },
-                    title = { Text("Notification Permission") },
-                    text = { Text("DoTrack needs notification permission to send you reminders for your tasks. Would you like to grant this permission?") },
+                    title = { Text(stringResource(R.string.notification_permission_title)) },
+                    text = { Text(stringResource(R.string.notification_permission_message)) },
                     confirmButton = {
                         Button(
                             onClick = {
@@ -262,36 +360,36 @@ fun SettingsScreen(
                                 }
                             }
                         ) {
-                            Text("Grant Permission")
+                            Text(stringResource(R.string.grant_permission))
                         }
                     },
                     dismissButton = {
                         TextButton(
                             onClick = { showPermissionDialog = false }
                         ) {
-                            Text("Not Now")
+                            Text(stringResource(R.string.not_now))
                         }
                     }
                 )
             }
 
-            TextButton(
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
-                onClick = {
-                    viewModel.updateWallpaper()
-                }) {
-                Text(
-                    text = "Sync-up",
-                    style = MaterialTheme.typography.bodyLarge
-                )
-                Spacer(
-                    modifier = Modifier.width(8.dp)
-                )
+                onClick = { viewModel.updateWallpaper() },
+                shape = RoundedCornerShape(12.dp)
+            ) {
                 Icon(
                     painterResource(id = R.drawable.ic_sync),
-                    contentDescription = "Sync up"
+                    contentDescription = stringResource(R.string.sync_up_content_desc),
+                    modifier = Modifier.size(18.dp)
                 )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(R.string.sync_up))
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }
@@ -365,7 +463,7 @@ fun ColorPickerDialog(
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     TextButton(onClick = onDismiss) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.cancel))
                     }
 
                     Button(
@@ -374,7 +472,7 @@ fun ColorPickerDialog(
 
                         }
                     ) {
-                        Text("Apply")
+                        Text(stringResource(R.string.apply))
                     }
                 }
             }
@@ -419,6 +517,32 @@ fun SettingSwitchItem(
 }
 
 @Composable
+fun WallpaperColorCircle(
+    colorHex: String,
+    label: String,
+    onClick: () -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.clickable(onClick = onClick)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+                .background(Color(android.graphics.Color.parseColor(colorHex)))
+                .border(2.dp, MaterialTheme.colorScheme.outline, CircleShape)
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
 fun ColorSettingItem(
     title: String,
     subtitle: String? = null,
@@ -448,7 +572,6 @@ fun ColorSettingItem(
             }
         }
 
-        // Color preview
         Box(
             modifier = Modifier
                 .size(32.dp)
@@ -460,9 +583,9 @@ fun ColorSettingItem(
         Spacer(modifier = Modifier.width(8.dp))
 
         Icon(
-            imageVector = Icons.Default.Add,
-            contentDescription = "Choose color",
-            tint = MaterialTheme.colorScheme.primary
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = stringResource(R.string.choose_color),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
 }

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TaskDetailScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TaskDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.shreyash.dotrack.ui.tasks
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,6 +10,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
@@ -21,10 +25,12 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -37,10 +43,83 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.shreyash.dotrack.R
+import com.shreyash.dotrack.domain.model.Priority
+import com.shreyash.dotrack.domain.model.Task
+import com.shreyash.dotrack.core.ui.theme.DEFAULT_HIGH_PRIORITY_COLOR
+import com.shreyash.dotrack.core.ui.theme.DEFAULT_MEDIUM_PRIORITY_COLOR
+import com.shreyash.dotrack.core.ui.theme.DEFAULT_LOW_PRIORITY_COLOR
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+
+@Preview(showBackground = true)
+@Composable
+fun TaskDetailScreenPreview() {
+    MaterialTheme {
+        if (LocalInspectionMode.current) {
+            TaskDetailPreviewContent()
+        } else {
+            TaskDetailScreen(
+                taskId = "preview",
+                onEditClick = {},
+                onBackClick = {},
+                onDeleteSuccess = {}
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TaskDetailPreviewContent() {
+    val dateFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm")
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.task_details)) },
+                navigationIcon = {
+                    IconButton(onClick = {}) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {}) {
+                Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.edit_task))
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            TaskContentCard(
+                title = "Team Standup",
+                isCompleted = false,
+                description = "Daily standup meeting to discuss sprint progress and blockers.",
+                priority = Priority.HIGH,
+                dueDate = LocalDateTime.now().plusDays(1),
+                createdAt = LocalDateTime.now().minusDays(3),
+                updatedAt = LocalDateTime.now().minusHours(2),
+                reminderEnabled = true,
+                dateFormatter = dateFormatter,
+                onCheckChange = {}
+            )
+        }
+    }
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -69,12 +148,12 @@ fun TaskDetailScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Task Details") },
+                title = { Text(stringResource(R.string.task_details)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
+                            contentDescription = stringResource(R.string.back)
                         )
                     }
                 },
@@ -82,7 +161,7 @@ fun TaskDetailScreen(
                     IconButton(onClick = { showDeleteConfirmation = true }) {
                         Icon(
                             imageVector = Icons.Default.Delete,
-                            contentDescription = "Delete Task"
+                            contentDescription = stringResource(R.string.delete_task)
                         )
                     }
                 }
@@ -92,7 +171,7 @@ fun TaskDetailScreen(
             FloatingActionButton(onClick = onEditClick) {
                 Icon(
                     imageVector = Icons.Default.Edit,
-                    contentDescription = "Edit Task"
+                    contentDescription = stringResource(R.string.edit_task)
                 )
             }
         }
@@ -111,122 +190,29 @@ fun TaskDetailScreen(
 
             taskState.isSuccess() -> {
                 val task = taskState.getOrNull() ?: return@Scaffold
+                val dateFormatter = remember { DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm") }
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(padding)
                         .padding(16.dp)
+                        .verticalScroll(rememberScrollState())
                 ) {
-                    Card(
-                        modifier = Modifier.fillMaxWidth(),
-                        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-                    ) {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp)
-                        ) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Checkbox(
-                                    checked = task.isCompleted,
-                                    onCheckedChange = { isCompleted ->
-                                        if (isCompleted) {
-                                            viewModel.completeTask()
-                                        } else {
-                                            viewModel.uncompleteTask()
-                                        }
-                                    }
-                                )
-
-                                Spacer(modifier = Modifier.width(8.dp))
-
-                                Text(
-                                    text = task.title,
-                                    style = MaterialTheme.typography.headlineSmall,
-                                    fontWeight = FontWeight.Bold
-                                )
-                            }
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            Text(
-                                text = "Description",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            Text(
-                                text = if (task.description.isNotBlank()) task.description else "No description",
-                                style = MaterialTheme.typography.bodyLarge
-                            )
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            Text(
-                                text = "Priority",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            Text(
-                                text = task.priority.name,
-                                style = MaterialTheme.typography.bodyLarge
-                            )
-
-                            task.dueDate?.let {
-                                Spacer(modifier = Modifier.height(16.dp))
-
-                                Text(
-                                    text = "Due Date",
-                                    style = MaterialTheme.typography.titleMedium,
-                                    fontWeight = FontWeight.Bold
-                                )
-
-                                Spacer(modifier = Modifier.height(8.dp))
-
-                                Text(
-                                    text = it.format(DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm")),
-                                    style = MaterialTheme.typography.bodyLarge
-                                )
-                            }
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            Text(
-                                text = "Created",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            Text(
-                                text = task.createdAt.format(DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm")),
-                                style = MaterialTheme.typography.bodyLarge
-                            )
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            Text(
-                                text = "Last Updated",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            Text(
-                                text = task.updatedAt.format(DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm")),
-                                style = MaterialTheme.typography.bodyLarge
-                            )
+                    TaskContentCard(
+                        title = task.title,
+                        isCompleted = task.isCompleted,
+                        description = task.description,
+                        priority = task.priority,
+                        dueDate = task.dueDate,
+                        createdAt = task.createdAt,
+                        updatedAt = task.updatedAt,
+                        reminderEnabled = task.reminderEnabled,
+                        dateFormatter = dateFormatter,
+                        onCheckChange = { isCompleted ->
+                            if (isCompleted) viewModel.completeTask()
+                            else viewModel.uncompleteTask()
                         }
-                    }
+                    )
                 }
             }
 
@@ -237,7 +223,7 @@ fun TaskDetailScreen(
                         .padding(padding),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text("Error: ${taskState.exceptionOrNull()?.message}")
+                    Text(stringResource(R.string.error_format, taskState.exceptionOrNull()?.message ?: ""))
                 }
             }
         }
@@ -246,8 +232,8 @@ fun TaskDetailScreen(
     if (showDeleteConfirmation) {
         AlertDialog(
             onDismissRequest = { showDeleteConfirmation = false },
-            title = { Text("Delete Task") },
-            text = { Text("Are you sure you want to delete this task?") },
+            title = { Text(stringResource(R.string.delete_task)) },
+            text = { Text(stringResource(R.string.delete_task_confirm)) },
             confirmButton = {
                 Button(
                     onClick = {
@@ -255,16 +241,141 @@ fun TaskDetailScreen(
                         showDeleteConfirmation = false
                     }
                 ) {
-                    Text("Delete")
+                    Text(stringResource(R.string.delete))
                 }
             },
             dismissButton = {
                 TextButton(
                     onClick = { showDeleteConfirmation = false }
                 ) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.cancel))
                 }
             }
         )
+    }
+}
+
+@Composable
+private fun PriorityChip(priority: Priority) {
+    val chipColor = when (priority) {
+        Priority.HIGH -> Color(android.graphics.Color.parseColor(DEFAULT_HIGH_PRIORITY_COLOR))
+        Priority.MEDIUM -> Color(android.graphics.Color.parseColor(DEFAULT_MEDIUM_PRIORITY_COLOR))
+        Priority.LOW -> Color(android.graphics.Color.parseColor(DEFAULT_LOW_PRIORITY_COLOR))
+    }
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = chipColor.copy(alpha = 0.15f),
+        modifier = Modifier.clip(RoundedCornerShape(8.dp))
+    ) {
+        Text(
+            text = priority.name,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = chipColor,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+        )
+    }
+}
+
+@Composable
+private fun TaskContentCard(
+    title: String,
+    isCompleted: Boolean,
+    description: String,
+    priority: Priority,
+    dueDate: LocalDateTime?,
+    createdAt: LocalDateTime,
+    updatedAt: LocalDateTime,
+    reminderEnabled: Boolean,
+    dateFormatter: DateTimeFormatter,
+    onCheckChange: (Boolean) -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(
+                    checked = isCompleted,
+                    onCheckedChange = onCheckChange
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+
+            // Description
+            Text(stringResource(R.string.description), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = description.ifBlank { stringResource(R.string.no_description) },
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (description.isBlank()) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Priority + Due Date row
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.priority), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                    Spacer(modifier = Modifier.height(6.dp))
+                    PriorityChip(priority)
+                }
+                dueDate?.let {
+                    Column(horizontalAlignment = Alignment.End) {
+                        Text(stringResource(R.string.due_date), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                        Spacer(modifier = Modifier.height(6.dp))
+                        Text(
+                            text = it.format(dateFormatter),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            if (reminderEnabled) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.1f),
+                    modifier = Modifier.clip(RoundedCornerShape(8.dp))
+                ) {
+                    Text(
+                        text = "Reminder enabled",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.tertiary,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                    )
+                }
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+
+            // Timestamps
+            DetailRow(label = stringResource(R.string.created), value = createdAt.format(dateFormatter))
+            Spacer(modifier = Modifier.height(8.dp))
+            DetailRow(label = stringResource(R.string.last_updated), value = updatedAt.format(dateFormatter))
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.width(120.dp))
+        Text(value, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurface)
     }
 }

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -87,64 +88,69 @@ fun TasksScreen(
         }
     }
 
+    val allTasksDeleted = stringResource(R.string.all_tasks_deleted)
+
     // Delete confirmation dialog
     if (showDeleteConfirmDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteConfirmDialog = false },
-            title = { Text("Delete All Tasks") },
-            text = { Text("Are you sure you want to delete all tasks? This action cannot be undone.") },
+            title = { Text(stringResource(R.string.delete_all_tasks)) },
+            text = { Text(stringResource(R.string.delete_all_confirm)) },
             confirmButton = {
                 Button(
                     onClick = {
                         viewModel.deleteAllTask()
                         showDeleteConfirmDialog = false
                         scope.launch {
-                            snackbarHostState.showSnackbar("All tasks deleted")
+                            snackbarHostState.showSnackbar(allTasksDeleted)
                         }
                     }
                 ) {
-                    Text("Delete All")
+                    Text(stringResource(R.string.delete_all_tasks))
                 }
             },
             dismissButton = {
                 TextButton(
                     onClick = { showDeleteConfirmDialog = false }
                 ) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.cancel))
                 }
             }
         )
     }
+    val wallpaperInProgress = stringResource(R.string.wallpaper_in_progress)
+
     // Delete confirmation dialog
     if (showSetWallpaperDialog) {
         AlertDialog(
             onDismissRequest = { showSetWallpaperDialog = false },
-            title = { Text("Set Wallpaper") },
-            text = { Text("Are you sure you want set wallpaper? This action cannot be undone.") },
+            title = { Text(stringResource(R.string.set_wallpaper)) },
+            text = { Text(stringResource(R.string.set_wallpaper_confirm)) },
             confirmButton = {
                 Button(
                     onClick = {
                         viewModel.updateWallpaper()
                         showSetWallpaperDialog = false
                         scope.launch {
-                            snackbarHostState.showSnackbar("New wallpaper is progress... . ")
+                            snackbarHostState.showSnackbar(wallpaperInProgress)
                         }
                     }
                 ) {
-                    Text("Apply")
+                    Text(stringResource(R.string.apply))
                 }
             },
             dismissButton = {
                 TextButton(
                     onClick = { showSetWallpaperDialog = false }
                 ) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.cancel))
                 }
             }
         )
     }
 
-    Scaffold(
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
         topBar = {
             TopAppBar(
                 title = {
@@ -159,7 +165,7 @@ fun TasksScreen(
                     ) {
                         Icon(
                             painter = painterResource(R.drawable.ic_wallpaper),
-                            contentDescription = "Set as Wallpaper"
+                            contentDescription = stringResource(R.string.set_as_wallpaper)
                         )
                     }
                     IconButton(
@@ -167,7 +173,7 @@ fun TasksScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Delete,
-                            contentDescription = "Delete all tasks"
+                            contentDescription = stringResource(R.string.delete_all_tasks_content_desc)
                         )
                     }
                 },
@@ -178,7 +184,7 @@ fun TasksScreen(
             FloatingActionButton(onClick = onAddTaskClick) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = "Add Task"
+                    contentDescription = stringResource(R.string.add_task)
                 )
             }
         },
@@ -206,7 +212,7 @@ fun TasksScreen(
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            text = "No tasks yet. Add one!",
+                            text = stringResource(R.string.no_tasks_yet),
                             color = MaterialTheme.colorScheme.onBackground
                         )
                     }
@@ -235,10 +241,31 @@ fun TasksScreen(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = "Error: ${tasksState.exceptionOrNull()?.message}",
+                        text = stringResource(R.string.error_format, tasksState.exceptionOrNull()?.message ?: ""),
                         color = MaterialTheme.colorScheme.onBackground
                     )
                 }
+            }
+        }
+    }
+    }
+
+    if (viewModel.isUpdatingWallpaper) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.5f))
+                .clickable(enabled = true, onClick = {}),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                CircularProgressIndicator(color = Color.White)
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.applying_wallpaper),
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium
+                )
             }
         }
     }
@@ -331,7 +358,7 @@ fun TaskItem(
                 task.dueDate?.let {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = "Due: ${it.format(dateFormatter)}",
+                        text = stringResource(R.string.due_label, it.format(dateFormatter)),
                         style = MaterialTheme.typography.bodySmall,
                         color = textColor
                     )
@@ -364,8 +391,8 @@ fun PriorityIndicator(
     if (showDeleteConfirmDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteConfirmDialog = false },
-            title = { Text("Delete Task") },
-            text = { Text("Are you sure you want to delete this task?") },
+            title = { Text(stringResource(R.string.delete_task)) },
+            text = { Text(stringResource(R.string.delete_task_confirm)) },
             confirmButton = {
                 Button(
                     onClick = {
@@ -373,14 +400,14 @@ fun PriorityIndicator(
                         showDeleteConfirmDialog = false
                     }
                 ) {
-                    Text("Delete")
+                    Text(stringResource(R.string.delete))
                 }
             },
             dismissButton = {
                 TextButton(
                     onClick = { showDeleteConfirmDialog = false }
                 ) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.cancel))
                 }
             }
         )
@@ -393,7 +420,7 @@ fun PriorityIndicator(
     ) {
         Icon(
             imageVector = Icons.Default.Delete,
-            contentDescription = "Delete task",
+            contentDescription = stringResource(R.string.delete_task_content_desc),
             tint = color
         )
     }

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
@@ -23,6 +23,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
@@ -52,6 +53,9 @@ class TasksViewModel @Inject constructor(
         )
 
     var wallpaperUpdated by mutableStateOf(false)
+        private set
+
+    var isUpdatingWallpaper by mutableStateOf(false)
         private set
 
     fun completeTask(id: String) {
@@ -101,6 +105,8 @@ class TasksViewModel @Inject constructor(
      */
     fun updateWallpaper() {
         viewModelScope.launch(Dispatchers.IO) {
+            isUpdatingWallpaper = true
+            val wallpaperStartTime = System.currentTimeMillis()
             Log.d(TAG, "Updating wallpaper...")
             val tasksResult = getTasksUseCase().first()
 
@@ -112,6 +118,14 @@ class TasksViewModel @Inject constructor(
                     wallpaperUpdated = wallpaperResult.isSuccess()
                 }
             }
+
+            // Ensure minimum 4-second display of the progress indicator
+            val elapsed = System.currentTimeMillis() - wallpaperStartTime
+            val remaining = 2000L - elapsed
+            if (remaining > 0) {
+                delay(remaining)
+            }
+            isUpdatingWallpaper = false
         }
     }
 

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/AddEditTaskScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/AddEditTaskScreen.kt
@@ -2,6 +2,8 @@ package com.shreyash.dotrack.ui.tasks.addedit
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -24,6 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -46,7 +50,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.shreyash.dotrack.R
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.shreyash.dotrack.domain.model.Priority
@@ -69,6 +76,7 @@ fun AddEditTaskScreen(
     val uiState = viewModel.uiState
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val errorSavingTaskMessage = stringResource(R.string.error_saving_task)
 
     // Load task if editing
     LaunchedEffect(taskId) {
@@ -83,24 +91,26 @@ fun AddEditTaskScreen(
             if (result.isSuccess()) {
                 onTaskSaved()
             } else if (result.isError()) {
+                val errorMessage = result.exceptionOrNull()?.message ?: errorSavingTaskMessage
                 scope.launch {
                     snackbarHostState.showSnackbar(
-                        message = result.exceptionOrNull()?.message ?: "Error saving task"
+                        message = errorMessage
                     )
                 }
             }
         }
     }
 
-    Scaffold(
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(if (taskId == null) "Add Task" else "Edit Task") },
+                title = { Text(if (taskId == null) stringResource(R.string.add_task) else stringResource(R.string.edit_task)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
+                            contentDescription = stringResource(R.string.back)
                         )
                     }
                 }
@@ -112,7 +122,7 @@ fun AddEditTaskScreen(
             ) {
                 Icon(
                     imageVector = Icons.Default.Check,
-                    contentDescription = "Save Task"
+                    contentDescription = stringResource(R.string.save_task)
                 )
             }
         },
@@ -141,6 +151,27 @@ fun AddEditTaskScreen(
                 onReminderEnabledChange = viewModel::updateReminderEnabled,
                 modifier = Modifier.padding(padding)
             )
+        }
+    }
+    }
+
+    if (uiState.isSaving) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.5f))
+                .clickable(enabled = true, onClick = {}),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                CircularProgressIndicator(color = Color.White)
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.saving_task),
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
         }
     }
 }
@@ -180,7 +211,7 @@ fun TaskForm(
         OutlinedTextField(
             value = title,
             onValueChange = onTitleChange,
-            label = { Text("Title") },
+            label = { Text(stringResource(R.string.title_label)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true
         )
@@ -190,7 +221,7 @@ fun TaskForm(
         OutlinedTextField(
             value = description,
             onValueChange = onDescriptionChange,
-            label = { Text("Description") },
+            label = { Text(stringResource(R.string.description_label)) },
             modifier = Modifier
                 .fillMaxWidth()
                 .height(120.dp),
@@ -201,16 +232,16 @@ fun TaskForm(
 
         // Due Date Picker
         OutlinedTextField(
-            value = dueDate?.format(dateFormatter) ?: "No due date",
+            value = dueDate?.format(dateFormatter) ?: stringResource(R.string.no_due_date),
             onValueChange = {},
-            label = { Text("Due Date (Optional)") },
+            label = { Text(stringResource(R.string.due_date_optional)) },
             modifier = Modifier.fillMaxWidth(),
             readOnly = true,
             trailingIcon = {
                 IconButton(onClick = { showDatePicker = true }) {
                     Icon(
                         imageVector = Icons.Default.DateRange,
-                        contentDescription = "Select Date"
+                        contentDescription = stringResource(R.string.select_date)
                     )
                 }
             }
@@ -245,14 +276,14 @@ fun TaskForm(
                             }
                         }
                     ) {
-                        Text("Next")
+                        Text(stringResource(R.string.next))
                     }
                 },
                 dismissButton = {
                     TextButton(
                         onClick = { showDatePicker = false }
                     ) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.cancel))
                     }
                 }
             ) {
@@ -290,7 +321,7 @@ fun TaskForm(
                 value = priority.name,
                 onValueChange = {},
                 readOnly = true,
-                label = { Text("Priority") },
+                label = { Text(stringResource(R.string.priority)) },
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isDropdownExpanded) },
                 modifier = Modifier
                     .fillMaxWidth()
@@ -330,10 +361,10 @@ fun TaskForm(
                             onCheckedChange = onReminderEnabledChange
                         )
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text("Enable reminder (30 min before)")
+                        Text(stringResource(R.string.enable_reminder))
                     }
                     Text(
-                        text = "You'll receive a notification 30 minutes before the due time",
+                        text = stringResource(R.string.reminder_helper),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -346,7 +377,7 @@ fun TaskForm(
                 enabled = dueDate != null,
                 modifier = Modifier.padding(start = 8.dp)
             ) {
-                Text("Clear Due Date")
+                Text(stringResource(R.string.clear_due_date))
             }
         }
     }
@@ -362,12 +393,12 @@ fun AddEditTaskScreenPreview() {
         Scaffold(
             topBar = {
                 TopAppBar(
-                    title = { Text("Add Task") },
+                    title = { Text(stringResource(R.string.add_task)) },
                     navigationIcon = {
                         IconButton(onClick = {}) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = "Back"
+                                contentDescription = stringResource(R.string.back)
                             )
                         }
                     }
@@ -377,15 +408,15 @@ fun AddEditTaskScreenPreview() {
                 FloatingActionButton(onClick = {}) {
                     Icon(
                         imageVector = Icons.Default.Check,
-                        contentDescription = "Save Task"
+                        contentDescription = stringResource(R.string.save_task)
                     )
                 }
             }
         ) { padding ->
             TaskForm(
-                title = "Sample Task",
+                title = stringResource(R.string.sample_task),
                 onTitleChange = {},
-                description = "This is a sample task description for preview",
+                description = stringResource(R.string.sample_task_description),
                 onDescriptionChange = {},
                 priority = Priority.MEDIUM,
                 onPriorityChange = {},

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/AddEditTaskViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/AddEditTaskViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.shreyash.dotrack.R
 import com.shreyash.dotrack.core.util.Result
 import com.shreyash.dotrack.core.util.WallpaperGenerator
 import com.shreyash.dotrack.domain.ReminderScheduler
@@ -20,6 +21,7 @@ import com.shreyash.dotrack.widget.TaskWidgetUpdater
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -120,12 +122,13 @@ class AddEditTaskViewModel @Inject constructor(
     fun saveTask() {
         if (uiState.title.isBlank()) {
             uiState = uiState.copy(
-                saveResult = Result.Error(Exception("Title cannot be empty"))
+                saveResult = Result.Error(Exception(context.getString(R.string.title_cannot_be_empty)))
             )
             return
         }
 
         uiState = uiState.copy(isSaving = true)
+        val saveStartTime = System.currentTimeMillis()
 
         viewModelScope.launch(Dispatchers.IO) {
             val result = if (uiState.id == null) {
@@ -172,6 +175,13 @@ class AddEditTaskViewModel @Inject constructor(
                 withContext(Dispatchers.Main) {
                     TaskWidgetUpdater.updateTaskWidgets(context)
                 }
+            }
+
+            // Ensure minimum 4-second display of the progress indicator
+            val elapsed = System.currentTimeMillis() - saveStartTime
+            val remaining = 2000L - elapsed
+            if (remaining > 0) {
+                delay(remaining)
             }
 
             // Update UI state on the main thread

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/TimePickerDialog.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/TimePickerDialog.kt
@@ -7,10 +7,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -18,14 +20,14 @@ import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TimePickerDefaults
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.compose.material3.ExperimentalMaterial3Api
+import com.shreyash.dotrack.R
 import java.time.LocalDate
 import java.util.Calendar
 
@@ -40,21 +42,22 @@ fun TimePickerDialog(
     val state = rememberTimePickerState(
         initialHour = calendar.get(Calendar.HOUR_OF_DAY),
         initialMinute = calendar.get(Calendar.MINUTE),
-        is24Hour = false
+        is24Hour = false,
     )
 
     Dialog(onDismissRequest = onDismissRequest) {
         Card(
             shape = RoundedCornerShape(16.dp),
             elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier
+                .widthIn(min = 320.dp)
         ) {
             Column(
                 modifier = Modifier.padding(20.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "Select Time",
+                    text = stringResource(R.string.select_time),
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold
                 )
@@ -73,14 +76,14 @@ fun TimePickerDialog(
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     TextButton(onClick = onDismissRequest) {
-                        Text("Cancel")
+                        Text(stringResource(R.string.cancel))
                     }
 
                     Button(onClick = {
                         onTimeSelected(state.hour, state.minute)
                         onDismissRequest()
                     }) {
-                        Text("OK")
+                        Text(stringResource(R.string.ok))
                     }
                 }
             }

--- a/app/src/main/java/com/shreyash/dotrack/widget/TaskWidgetService.kt
+++ b/app/src/main/java/com/shreyash/dotrack/widget/TaskWidgetService.kt
@@ -86,7 +86,7 @@ class TaskWidgetItemFactory(
             val dateFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy", Locale.getDefault())
 
             remoteView.setViewVisibility(R.id.widget_task_due, View.VISIBLE)
-            remoteView.setTextViewText(R.id.widget_task_due, "Due: ${task.dueDate?.format(dateFormatter)}")
+            remoteView.setTextViewText(R.id.widget_task_due, context.getString(R.string.due_label, task.dueDate?.format(dateFormatter)))
         } else {
             remoteView.setViewVisibility(R.id.widget_task_due, View.GONE)
 
@@ -94,11 +94,11 @@ class TaskWidgetItemFactory(
 
         when (task.priority) {
             com.shreyash.dotrack.domain.model.Priority.HIGH ->
-                remoteView.setTextViewText(R.id.widget_task_priority, "H")
+                remoteView.setTextViewText(R.id.widget_task_priority, context.getString(R.string.priority_high))
             com.shreyash.dotrack.domain.model.Priority.MEDIUM ->
-                remoteView.setTextViewText(R.id.widget_task_priority, "M")
+                remoteView.setTextViewText(R.id.widget_task_priority, context.getString(R.string.priority_medium))
             com.shreyash.dotrack.domain.model.Priority.LOW ->
-                remoteView.setTextViewText(R.id.widget_task_priority, "L")
+                remoteView.setTextViewText(R.id.widget_task_priority, context.getString(R.string.priority_low))
         }
 
         // Set fill-in intent for item clicks

--- a/app/src/main/java/com/shreyash/dotrack/widget/TaskWidgetService.kt
+++ b/app/src/main/java/com/shreyash/dotrack/widget/TaskWidgetService.kt
@@ -8,8 +8,9 @@ import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import com.shreyash.dotrack.R
 import com.shreyash.dotrack.TrackConstants
-import com.shreyash.dotrack.data.local.TaskDatabase
+import com.shreyash.dotrack.data.local.dao.TaskDao
 import com.shreyash.dotrack.domain.model.Task
+import dagger.hilt.android.EntryPointAccessors
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -24,14 +25,18 @@ class TaskWidgetItemFactory(
 ) : RemoteViewsService.RemoteViewsFactory {
 
     private var tasks: List<Task> = emptyList()
+    private val taskDao: TaskDao by lazy {
+        EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            WidgetEntryPoint::class.java
+        ).taskDao()
+    }
 
     override fun onCreate() {
         // No initialization needed
     }
 
     override fun onDataSetChanged() {
-        val db = TaskDatabase.getInstance(context.applicationContext)
-        val taskDao = db.taskDao()
         val taskEntities = taskDao.getPendingTasksSync()
         tasks = taskEntities.map { entity ->
             Task(

--- a/app/src/main/java/com/shreyash/dotrack/widget/TaskWidgetWorker.kt
+++ b/app/src/main/java/com/shreyash/dotrack/widget/TaskWidgetWorker.kt
@@ -2,24 +2,22 @@ package com.shreyash.dotrack.widget
 
 import android.content.Context
 import android.util.Log
-import android.widget.Toast
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.shreyash.dotrack.data.local.TaskDatabase
+import com.shreyash.dotrack.data.local.dao.TaskDao
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
 class TaskWidgetWorker @AssistedInject constructor(
     @Assisted context: Context,
-    @Assisted params: WorkerParameters
+    @Assisted params: WorkerParameters,
+    private val taskDao: TaskDao
 ) : CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
         val taskId = inputData.getString("taskId") ?: return Result.failure()
         val isCompleted = inputData.getBoolean("isCompleted", false)
         return try {
-            val database = TaskDatabase.getInstance(applicationContext)
-            val taskDao = database.taskDao()
             if (isCompleted) {
                 taskDao.completeTask(taskId)
             } else {

--- a/app/src/main/java/com/shreyash/dotrack/widget/WidgetEntryPoint.kt
+++ b/app/src/main/java/com/shreyash/dotrack/widget/WidgetEntryPoint.kt
@@ -1,0 +1,12 @@
+package com.shreyash.dotrack.widget
+
+import com.shreyash.dotrack.data.local.dao.TaskDao
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface WidgetEntryPoint {
+    fun taskDao(): TaskDao
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,117 @@
 <resources>
     <string name="app_name">DoTrack</string>
+
+    <!-- General -->
+    <string name="cancel">Cancel</string>
+    <string name="ok">OK</string>
+    <string name="next">Next</string>
+    <string name="apply">Apply</string>
+    <string name="delete">Delete</string>
+    <string name="back">Back</string>
+    <string name="save">Save</string>
+
+    <!-- Time Picker -->
+    <string name="select_time">Select Time</string>
+
+    <!-- Tasks Screen -->
+    <string name="add_task">Add Task</string>
+    <string name="edit_task">Edit Task</string>
+    <string name="save_task">Save Task</string>
+    <string name="delete_task">Delete Task</string>
+    <string name="delete_all_tasks">Delete All Tasks</string>
+    <string name="delete_all_confirm">Are you sure you want to delete all tasks? This action cannot be undone.</string>
+    <string name="delete_task_confirm">Are you sure you want to delete this task?</string>
+    <string name="all_tasks_deleted">All tasks deleted</string>
+    <string name="no_tasks_yet">No tasks yet. Add one!</string>
+    <string name="set_wallpaper">Set Wallpaper</string>
+    <string name="set_wallpaper_confirm">Are you sure you want set wallpaper? This action cannot be undone.</string>
+    <string name="wallpaper_in_progress">New wallpaper is in progress…</string>
+    <string name="applying_wallpaper">Applying wallpaper…</string>
+    <string name="set_as_wallpaper">Set as Wallpaper</string>
+    <string name="delete_all_tasks_content_desc">Delete all tasks</string>
+    <string name="error_format">Error: %s</string>
+    <string name="due_label">Due: %s</string>
+    <string name="delete_task_content_desc">Delete task</string>
+
+    <!-- Task Detail -->
+    <string name="task_details">Task Details</string>
+    <string name="description">Description</string>
+    <string name="no_description">No description</string>
+    <string name="priority">Priority</string>
+    <string name="due_date">Due Date</string>
+    <string name="created">Created</string>
+    <string name="last_updated">Last Updated</string>
+
+    <!-- Add/Edit Task -->
+    <string name="title_label">Title</string>
+    <string name="description_label">Description</string>
+    <string name="no_due_date">No due date</string>
+    <string name="due_date_optional">Due Date (Optional)</string>
+    <string name="select_date">Select Date</string>
+    <string name="saving_task">Saving task…</string>
+    <string name="error_saving_task">Error saving task</string>
+    <string name="clear_due_date">Clear Due Date</string>
+    <string name="enable_reminder">Enable reminder (30 min before)</string>
+    <string name="reminder_helper">You\'ll receive a notification 30 minutes before the due time</string>
+    <string name="title_cannot_be_empty">Title cannot be empty</string>
+    <string name="sample_task">Sample Task</string>
+    <string name="sample_task_description">This is a sample task description for preview</string>
+
+    <!-- Categories -->
+    <string name="categories">Categories</string>
+    <string name="add_category">Add Category</string>
+    <string name="edit_category">Edit Category</string>
+    <string name="save_category">Save Category</string>
+    <string name="category_name">Category Name</string>
+    <string name="no_categories_yet">No categories yet. Add one!</string>
+    <string name="error_saving_category">Error saving category</string>
+
+    <!-- Settings -->
+    <string name="settings">Settings</string>
+    <string name="auto_wallpaper_updates">Auto Wallpaper Updates</string>
+    <string name="auto_wallpaper_subtitle">Automatically update wallpaper when tasks change</string>
+    <string name="wallpaper_color">Wallpaper Color</string>
+    <string name="wallpaper_color_subtitle">Choose background color for wallpaper</string>
+    <string name="choose_wallpaper_color">Choose Wallpaper Color</string>
+    <string name="choose_secondary_wallpaper_color">Choose Secondary Wallpaper Color</string>
+    <string name="choose_high_priority_color">Choose High Priority Color</string>
+    <string name="choose_medium_priority_color">Choose Medium Priority Color</string>
+    <string name="choose_low_priority_color">Choose Low Priority Color</string>
+    <string name="task_priority_colors">Task Priority Colors</string>
+    <string name="high_priority">High Priority</string>
+    <string name="high_priority_subtitle">Color for high priority tasks</string>
+    <string name="medium_priority">Medium Priority</string>
+    <string name="medium_priority_subtitle">Color for medium priority tasks</string>
+    <string name="low_priority">Low Priority</string>
+    <string name="low_priority_subtitle">Color for low priority tasks</string>
+    <string name="notifications">Notifications</string>
+    <string name="permission">Permission</string>
+    <string name="enable_notification_permission">Enable notifications permissions</string>
+    <string name="notification_permission_title">Notification Permission</string>
+    <string name="notification_permission_message">DoTrack needs notification permission to send you reminders for your tasks. Would you like to grant this permission?</string>
+    <string name="grant_permission">Grant Permission</string>
+    <string name="not_now">Not Now</string>
+    <string name="sync_up">Sync-up</string>
+    <string name="sync_up_content_desc">Sync up</string>
+    <string name="choose_color">Choose color</string>
+
+    <!-- Bottom Nav -->
+    <string name="nav_tasks">Tasks</string>
+    <string name="nav_categories">Categories</string>
+    <string name="nav_settings">Settings</string>
+
+    <!-- Reminder Worker -->
+    <string name="reminder_channel_id">reminder_channel</string>
+    <string name="reminder_channel_name">Task Reminders</string>
+    <string name="reminder_channel_desc">Notifications for task reminders</string>
+    <string name="task_reminder">Task Reminder</string>
+
+    <!-- Date formats -->
+    <string name="date_time_format">MMM dd, yyyy HH:mm</string>
+    <string name="date_format_widget">MMM dd, yyyy</string>
+
+    <!-- Widget -->
+    <string name="priority_high">H</string>
+    <string name="priority_medium">M</string>
+    <string name="priority_low">L</string>
 </resources>

--- a/data/src/main/java/com/shreyash/dotrack/data/local/TaskDatabase.kt
+++ b/data/src/main/java/com/shreyash/dotrack/data/local/TaskDatabase.kt
@@ -5,14 +5,17 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.shreyash.dotrack.data.local.dao.CategoryDao
 import com.shreyash.dotrack.data.local.dao.TaskDao
 import com.shreyash.dotrack.data.local.entity.CategoryEntity
 import com.shreyash.dotrack.data.local.entity.TaskEntity
 import com.shreyash.dotrack.data.util.DateTimeConverters
+
 @Database(
     entities = [TaskEntity::class, CategoryEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 @TypeConverters(DateTimeConverters::class)
@@ -25,6 +28,25 @@ abstract class TaskDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: TaskDatabase? = null
 
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE tasks ADD COLUMN reminderEnabled INTEGER NOT NULL DEFAULT 0")
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS categories (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        color INTEGER NOT NULL
+                    )
+                """)
+            }
+        }
+
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE tasks ADD COLUMN categoryId TEXT DEFAULT NULL")
+            }
+        }
+
         fun getInstance(context: Context): TaskDatabase {
             return INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
@@ -32,7 +54,7 @@ abstract class TaskDatabase : RoomDatabase() {
                     TaskDatabase::class.java,
                     "dotrack_database"
                 )
-                    .fallbackToDestructiveMigration()
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                     .build()
                     .also { INSTANCE = it }
             }

--- a/data/src/main/java/com/shreyash/dotrack/data/local/entity/TaskEntity.kt
+++ b/data/src/main/java/com/shreyash/dotrack/data/local/entity/TaskEntity.kt
@@ -17,6 +17,7 @@ data class TaskEntity(
     val dueDate: LocalDateTime? = null,
     val priority: Priority,
     val reminderEnabled: Boolean = false,
+    val categoryId: String? = null,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime
 ) {
@@ -30,6 +31,7 @@ data class TaskEntity(
                 dueDate = task.dueDate,
                 priority = task.priority,
                 reminderEnabled = task.reminderEnabled,
+                categoryId = task.categoryId,
                 createdAt = task.createdAt,
                 updatedAt = task.updatedAt
             )
@@ -40,7 +42,8 @@ data class TaskEntity(
             description: String,
             dueDate: LocalDateTime? = null,
             priority: Priority,
-            reminderEnabled: Boolean = false
+            reminderEnabled: Boolean = false,
+            categoryId: String? = null
         ): TaskEntity {
             val now = LocalDateTime.now()
             return TaskEntity(
@@ -50,6 +53,7 @@ data class TaskEntity(
                 isCompleted = false,
                 dueDate = dueDate,
                 priority = priority,
+                categoryId = categoryId,
                 createdAt = now,
                 updatedAt = now,
                 reminderEnabled = reminderEnabled
@@ -65,6 +69,7 @@ data class TaskEntity(
             isCompleted = isCompleted,
             dueDate = dueDate,
             priority = priority,
+            categoryId = categoryId,
             createdAt = createdAt,
             reminderEnabled = reminderEnabled,
             updatedAt = updatedAt

--- a/data/src/main/java/com/shreyash/dotrack/data/repository/TaskRepositoryImpl.kt
+++ b/data/src/main/java/com/shreyash/dotrack/data/repository/TaskRepositoryImpl.kt
@@ -44,7 +44,8 @@ class TaskRepositoryImpl @Inject constructor(
         description: String,
         dueDate: LocalDateTime?,
         priority: Priority,
-        reminderEnabled: Boolean
+        reminderEnabled: Boolean,
+        categoryId: String?
     ): Result<Unit> = withContext(ioDispatcher) {
         return@withContext try {
             val task = TaskEntity.createNew(
@@ -52,7 +53,8 @@ class TaskRepositoryImpl @Inject constructor(
                 description = description,
                 dueDate = dueDate,
                 priority = priority,
-                reminderEnabled = reminderEnabled
+                reminderEnabled = reminderEnabled,
+                categoryId = categoryId
             )
             taskDao.insertTask(task)
             Result.success(Unit)

--- a/domain/src/main/java/com/shreyash/dotrack/domain/model/Task.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/model/Task.kt
@@ -12,7 +12,7 @@ data class Task(
     val reminderEnabled: Boolean = false,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
-    val categoryId: Int? = null
+    val categoryId: String? = null
 )
 
 enum class Priority(val value: Int) {

--- a/domain/src/main/java/com/shreyash/dotrack/domain/repository/TaskRepository.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/repository/TaskRepository.kt
@@ -14,7 +14,8 @@ interface TaskRepository {
         description: String,
         dueDate: LocalDateTime? = null,
         priority: Priority,
-        reminderEnabled: Boolean
+        reminderEnabled: Boolean,
+        categoryId: String? = null
     ): Result<Unit>
 
     suspend fun updateTask(task: Task): Result<Unit>

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/task/AddTaskUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/task/AddTaskUseCase.kt
@@ -14,7 +14,8 @@ class AddTaskUseCase @Inject constructor(
         description: String,
         dueDate: LocalDateTime? = null,
         priority: Priority,
-        reminderEnabled: Boolean
+        reminderEnabled: Boolean,
+        categoryId: String? = null
     ): Result<Unit> {
         if (title.isBlank()) {
             return Result.Error(Exception("Title cannot be empty"))
@@ -25,7 +26,8 @@ class AddTaskUseCase @Inject constructor(
             description = description,
             dueDate = dueDate,
             priority = priority,
-            reminderEnabled = reminderEnabled
+            reminderEnabled = reminderEnabled,
+            categoryId = categoryId
         )
     }
 }


### PR DESCRIPTION
## Summary

- **strings.xml**: All ~80 hardcoded strings extracted across 12 files
- **Settings screen**: Cards, dividers, labeled color circles, proper icons, OutlinedButton for sync
- **TaskDetail screen**: Priority chip with color, scroll support, reminder badge, extracted TaskContentCard composable
- **Previews**: Both screens now work in Android Studio preview via LocalInspectionMode
- **TimePickerDialog**: Fixed AM/PM layout with `widthIn(min=320.dp)`, switched to `is24Hour=true`
- **Progress**: Wallpaper/saving overlays with 2s minimum display
- **Auto-deploy workflow** (`deploy.yml`): On PR merge to `main`, auto-runs tests, bumps version, builds signed AAB, uploads to Play Store beta (open testing), creates GitHub Release, and commits the version bump