### PR TITLE
Polish UI/UX: sort/filter bottom sheets, dark mode, settings improvements

### DIFF
--- a/.github/workflows/build_bundle.yml
+++ b/.github/workflows/build_bundle.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test
 
+      - name: Run lint checks (production readiness)
+        run: ./gradlew lint
+
       - name: Build AAB (bundleRelease)
         env:
           ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/keystore_details/release.keystore

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
         }
     }
 

--- a/app/src/main/java/com/shreyash/dotrack/MainActivity.kt
+++ b/app/src/main/java/com/shreyash/dotrack/MainActivity.kt
@@ -1,10 +1,12 @@
 package com.shreyash.dotrack
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -13,13 +15,16 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.shreyash.dotrack.core.ui.theme.DoTrackTheme
@@ -27,6 +32,7 @@ import com.shreyash.dotrack.navigation.DeepLinkHandler
 import com.shreyash.dotrack.navigation.DoTrackBottomNavigation
 import com.shreyash.dotrack.navigation.DoTrackNavHost
 import com.shreyash.dotrack.navigation.bottomNavDestinations
+import com.shreyash.dotrack.ui.ThemeViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -62,16 +68,27 @@ fun DoTrackApp(
     getDeepLinkIntent: () -> Intent? = { null }
 ) {
     val deepLinkIntent = remember(deepLinkTrigger) { getDeepLinkIntent() }
-    DoTrackTheme {
+
+    val themeViewModel: ThemeViewModel = if (LocalInspectionMode.current) {
+        hiltViewModel()
+    } else {
+        hiltViewModel()
+    }
+    val darkModePref by themeViewModel.darkMode.collectAsState()
+    val isDark = when (darkModePref) {
+        "dark" -> true
+        "light" -> false
+        else -> isSystemInDarkTheme()
+    }
+
+    DoTrackTheme(darkTheme = isDark) {
         val navController = rememberNavController()
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentDestination = navBackStackEntry?.destination
 
         val showBottomBar = currentDestination?.route in bottomNavDestinations.map { it.route }
 
-        // Handle deep link intent
         if (deepLinkIntent != null) {
-            // Use LaunchedEffect to handle the deep link after the NavHost is set up
             LaunchedEffect(deepLinkIntent) {
                 DeepLinkHandler.handleIntent(deepLinkIntent, navController)
             }

--- a/app/src/main/java/com/shreyash/dotrack/ui/ThemeViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/ThemeViewModel.kt
@@ -1,0 +1,35 @@
+package com.shreyash.dotrack.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shreyash.dotrack.domain.usecase.preferences.GetDarkModeUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.SetDarkModeUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ThemeViewModel @Inject constructor(
+    private val getDarkModeUseCase: GetDarkModeUseCase,
+    private val setDarkModeUseCase: SetDarkModeUseCase
+) : ViewModel() {
+
+    val darkMode = getDarkModeUseCase()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "system")
+
+    var isUpdating by mutableStateOf(false)
+        private set
+
+    fun setDarkMode(mode: String) {
+        viewModelScope.launch {
+            isUpdating = true
+            setDarkModeUseCase(mode)
+            isUpdating = false
+        }
+    }
+}

--- a/app/src/main/java/com/shreyash/dotrack/ui/categories/AddEditCategoryScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/categories/AddEditCategoryScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.shreyash.dotrack.R
@@ -110,5 +111,17 @@ fun AddEditCategoryScreen(
                 singleLine = true
             )
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddEditCategoryScreenPreview() {
+    MaterialTheme {
+        AddEditCategoryScreen(
+            categoryId = null,
+            onBackClick = {},
+            onCategorySaved = {}
+        )
     }
 }

--- a/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -155,6 +156,7 @@ fun SettingsScreen(
     val isAutoWallpaperEnabled by viewModel.autoWallpaperEnabled.collectAsState()
     val currentWallpaperColor by viewModel.wallpaperColor.collectAsState()
     val secondaryWallpaperColor by viewModel.wallpaperSecondaryColor.collectAsState()
+    val currentDarkMode by viewModel.darkMode.collectAsState()
 
     // Notification permission state
     val isNotificationEnabled = viewModel.notificationPermissionState
@@ -308,6 +310,48 @@ fun SettingsScreen(
                         subtitle = stringResource(R.string.low_priority_subtitle),
                         colorHex = currentLowPriorityColor,
                         onClick = { viewModel.showPriorityColorPicker(Priority.LOW) }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Appearance Section
+            Text(
+                text = stringResource(R.string.appearance),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+                )
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    DarkModeOption(
+                        label = stringResource(R.string.dark_mode_system),
+                        selected = currentDarkMode == "system",
+                        onClick = { viewModel.setDarkMode("system") }
+                    )
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+                    DarkModeOption(
+                        label = stringResource(R.string.dark_mode_light),
+                        selected = currentDarkMode == "light",
+                        onClick = { viewModel.setDarkMode("light") }
+                    )
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                    )
+                    DarkModeOption(
+                        label = stringResource(R.string.dark_mode_dark),
+                        selected = currentDarkMode == "dark",
+                        onClick = { viewModel.setDarkMode("dark") }
                     )
                 }
             }
@@ -543,6 +587,34 @@ fun WallpaperColorCircle(
 }
 
 @Composable
+fun DarkModeOption(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f)
+        )
+        if (selected) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}
+
+@Composable
 fun ColorSettingItem(
     title: String,
     subtitle: String? = null,
@@ -586,6 +658,69 @@ fun ColorSettingItem(
             imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
             contentDescription = stringResource(R.string.choose_color),
             tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ColorPickerDialogPreview() {
+    MaterialTheme {
+        ColorPickerDialog(
+            initialColor = Color(0xFF1A2980),
+            title = "Choose Color",
+            onColorSelected = {},
+            onDismiss = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingSwitchItemPreview() {
+    MaterialTheme {
+        SettingSwitchItem(
+            title = "Auto Wallpaper Updates",
+            subtitle = "Automatically update wallpaper when tasks change",
+            checked = true,
+            onCheckedChange = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WallpaperColorCirclePreview() {
+    MaterialTheme {
+        WallpaperColorCircle(
+            colorHex = "#1A2980",
+            label = "Primary",
+            onClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DarkModeOptionPreview() {
+    MaterialTheme {
+        DarkModeOption(
+            label = "System Default",
+            selected = true,
+            onClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ColorSettingItemPreview() {
+    MaterialTheme {
+        ColorSettingItem(
+            title = "High Priority",
+            subtitle = "Color for high priority tasks",
+            colorHex = "#FF4444",
+            onClick = {}
         )
     }
 }

--- a/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsViewModel.kt
@@ -17,14 +17,17 @@ import com.shreyash.dotrack.core.ui.theme.DEFAULT_LOW_PRIORITY_COLOR
 import com.shreyash.dotrack.core.ui.theme.DEFAULT_MEDIUM_PRIORITY_COLOR
 import com.shreyash.dotrack.core.ui.theme.DEFAULT_TOP_COLOR
 import com.shreyash.dotrack.core.util.WallpaperGenerator
+import com.shreyash.dotrack.domain.model.DarkMode
 import com.shreyash.dotrack.domain.model.Priority
 import com.shreyash.dotrack.domain.usecase.preferences.GetAutoWallpaperEnabledUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetDarkModeUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetHighPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetLowPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetMediumPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetSecondaryWallpaperColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetWallpaperColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetAutoWallpaperEnabledUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.SetDarkModeUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetHighPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetLowPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetMediumPriorityColorUseCase
@@ -58,6 +61,8 @@ class SettingsViewModel @Inject constructor(
     private val setLowPriorityColorUseCase: SetLowPriorityColorUseCase,
     private val wallpaperGenerator: WallpaperGenerator,
     private val getTasksUseCase: GetTasksUseCase,
+    private val getDarkModeUseCase: GetDarkModeUseCase,
+    private val setDarkModeUseCase: SetDarkModeUseCase,
 ) : ViewModel() {
 
 
@@ -125,6 +130,25 @@ class SettingsViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = DEFAULT_LOW_PRIORITY_COLOR // Default low priority color
         )
+
+    /**
+     * Dark mode state
+     */
+    val darkMode: StateFlow<String> = getDarkModeUseCase()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = DarkMode.SYSTEM.value
+        )
+
+    /**
+     * Set dark mode
+     */
+    fun setDarkMode(mode: String) {
+        viewModelScope.launch {
+            setDarkModeUseCase(mode)
+        }
+    }
 
     /**
      * Show color picker dialog state

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/FilterBottomSheet.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/FilterBottomSheet.kt
@@ -1,0 +1,149 @@
+package com.shreyash.dotrack.ui.tasks
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.shreyash.dotrack.R
+import com.shreyash.dotrack.domain.model.Priority
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FilterBottomSheet(
+    onDismiss: () -> Unit,
+    currentPriorityFilter: Priority?,
+    currentStatusFilter: Boolean?,
+    onPriorityFilterSelected: (Priority?) -> Unit,
+    onStatusFilterSelected: (Boolean?) -> Unit,
+    onReset: () -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ) {
+        Column(modifier = Modifier.padding(bottom = 16.dp)) {
+            Text(
+                text = stringResource(R.string.filter_by),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+            )
+
+            Text(
+                text = stringResource(R.string.filter_status),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(start = 24.dp, top = 8.dp, bottom = 4.dp)
+            )
+
+            FilterOptionItem(
+                label = stringResource(R.string.filter_all),
+                isSelected = currentStatusFilter == null,
+                onClick = { onStatusFilterSelected(null); onDismiss() }
+            )
+            FilterOptionItem(
+                label = stringResource(R.string.filter_active),
+                isSelected = currentStatusFilter == false,
+                onClick = { onStatusFilterSelected(false); onDismiss() }
+            )
+            FilterOptionItem(
+                label = stringResource(R.string.filter_completed),
+                isSelected = currentStatusFilter == true,
+                onClick = { onStatusFilterSelected(true); onDismiss() }
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp))
+
+            Text(
+                text = stringResource(R.string.priority),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(start = 24.dp, top = 8.dp, bottom = 4.dp)
+            )
+
+            FilterOptionItem(
+                label = stringResource(R.string.filter_all),
+                isSelected = currentPriorityFilter == null,
+                onClick = { onPriorityFilterSelected(null); onDismiss() }
+            )
+            FilterOptionItem(
+                label = stringResource(R.string.high_priority),
+                isSelected = currentPriorityFilter == Priority.HIGH,
+                onClick = { onPriorityFilterSelected(Priority.HIGH); onDismiss() }
+            )
+            FilterOptionItem(
+                label = stringResource(R.string.medium_priority),
+                isSelected = currentPriorityFilter == Priority.MEDIUM,
+                onClick = { onPriorityFilterSelected(Priority.MEDIUM); onDismiss() }
+            )
+            FilterOptionItem(
+                label = stringResource(R.string.low_priority),
+                isSelected = currentPriorityFilter == Priority.LOW,
+                onClick = { onPriorityFilterSelected(Priority.LOW); onDismiss() }
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp))
+
+            TextButton(
+                onClick = { onReset(); onDismiss() },
+                modifier = Modifier.padding(start = 8.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.reset),
+                    color = MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterOptionItem(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (isSelected) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+            Spacer(modifier = Modifier.padding(start = if (isSelected) 16.dp else 48.dp))
+            Text(
+                text = label,
+                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/SortBottomSheet.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/SortBottomSheet.kt
@@ -1,0 +1,185 @@
+package com.shreyash.dotrack.ui.tasks
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.shreyash.dotrack.R
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
+import kotlinx.coroutines.launch
+
+@ExperimentalMaterial3Api
+@Composable
+fun SortBottomSheet(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    currentSort: SortOption,
+    currentDirection: SortDirection,
+    onSortOptionSelected: (SortOption) -> Unit,
+    onToggleDirection: () -> Unit
+) {
+    if (expanded) {
+        ModalBottomSheet(
+            sheetState = rememberModalBottomSheetState(),
+            containerColor = MaterialTheme.colorScheme.surface,
+            onDismissRequest = onDismiss,
+            dragHandle = {
+                BottomSheetDefaults.DragHandle(
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalAlignment = Alignment.Start
+            ) {
+                SortOptionEntry(
+                    label = stringResource(R.string.sort_due_date),
+                    selected = currentSort == SortOption.DUE_DATE,
+                    onClick = { onSortOptionSelected(SortOption.DUE_DATE); onDismiss() }
+                )
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+                SortOptionEntry(
+                    label = stringResource(R.string.sort_priority),
+                    selected = currentSort == SortOption.PRIORITY,
+                    onClick = { onSortOptionSelected(SortOption.PRIORITY); onDismiss() }
+                )
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+                SortOptionEntry(
+                    label = stringResource(R.string.sort_created_date),
+                    selected = currentSort == SortOption.CREATED_DATE,
+                    onClick = { onSortOptionSelected(SortOption.CREATED_DATE); onDismiss() }
+                )
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+                SortOptionEntry(
+                    label = stringResource(R.string.sort_title),
+                    selected = currentSort == SortOption.TITLE,
+                    onClick = { onSortOptionSelected(SortOption.TITLE); onDismiss() }
+                )
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+                DirectionSelection(
+                    currentDirection = currentDirection,
+                    onToggleDirection = onToggleDirection
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SortOptionEntry(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    androidx.compose.material3.Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        color = if (selected) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (selected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f)
+            )
+            if (selected) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DirectionSelection(
+    currentDirection: SortDirection,
+    onToggleDirection: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onToggleDirection() }
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text(
+            text = if (currentDirection == SortDirection.ASCENDING)
+                stringResource(R.string.sort_ascending) else stringResource(R.string.sort_descending),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f)
+        )
+        Icon(
+            imageVector = if (currentDirection == SortDirection.ASCENDING)
+                Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+    }
+}
+
+@ExperimentalMaterial3Api
+@Preview(showBackground = true)
+@Composable
+private fun SortBottomSheetPreview() {
+    MaterialTheme {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.TopStart
+        ) {
+            SortBottomSheet(
+                expanded = true,
+                onDismiss = {},
+                currentSort = SortOption.DUE_DATE,
+                currentDirection = SortDirection.ASCENDING,
+                onSortOptionSelected = {},
+                onToggleDirection = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/SortDropdownMenu.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/SortDropdownMenu.kt
@@ -1,0 +1,155 @@
+package com.shreyash.dotrack.ui.tasks
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.shreyash.dotrack.R
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SortDropdownMenu(
+    onDismiss: () -> Unit,
+    currentSort: SortOption,
+    currentDirection: SortDirection,
+    onSortOptionSelected: (SortOption) -> Unit,
+    onToggleDirection: () -> Unit,
+    onReset: () -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ) {
+        Column(modifier = Modifier.padding(bottom = 16.dp)) {
+            Text(
+                text = stringResource(R.string.sort_by),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+            )
+
+            SortOptionItem(
+                label = stringResource(R.string.sort_due_date),
+                isSelected = currentSort == SortOption.DUE_DATE,
+                onClick = { onSortOptionSelected(SortOption.DUE_DATE); onDismiss() }
+            )
+            SortOptionItem(
+                label = stringResource(R.string.sort_priority),
+                isSelected = currentSort == SortOption.PRIORITY,
+                onClick = { onSortOptionSelected(SortOption.PRIORITY); onDismiss() }
+            )
+            SortOptionItem(
+                label = stringResource(R.string.sort_created_date),
+                isSelected = currentSort == SortOption.CREATED_DATE,
+                onClick = { onSortOptionSelected(SortOption.CREATED_DATE); onDismiss() }
+            )
+            SortOptionItem(
+                label = stringResource(R.string.sort_title),
+                isSelected = currentSort == SortOption.TITLE,
+                onClick = { onSortOptionSelected(SortOption.TITLE); onDismiss() }
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp))
+
+            SortDirectionItem(
+                isAscending = currentDirection == SortDirection.ASCENDING,
+                onClick = { onToggleDirection(); onDismiss() }
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp))
+
+            TextButton(
+                onClick = { onReset(); onDismiss() },
+                modifier = Modifier.padding(start = 8.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.reset),
+                    color = MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SortOptionItem(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (isSelected) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+            Spacer(modifier = Modifier.padding(start = if (isSelected) 16.dp else 48.dp))
+            Text(
+                text = label,
+                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}
+
+@Composable
+private fun SortDirectionItem(
+    isAscending: Boolean,
+    onClick: () -> Unit
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = if (isAscending) Icons.Default.KeyboardArrowUp
+                else Icons.Default.KeyboardArrowDown,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Spacer(modifier = Modifier.padding(start = 16.dp))
+            Text(
+                text = if (isAscending) stringResource(R.string.sort_ascending)
+                else stringResource(R.string.sort_descending),
+                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TaskComponents.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TaskComponents.kt
@@ -1,0 +1,279 @@
+package com.shreyash.dotrack.ui.tasks
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.shreyash.dotrack.R
+import com.shreyash.dotrack.core.ui.theme.CardColorHighPriority
+import com.shreyash.dotrack.core.ui.theme.CardColorLowPriority
+import com.shreyash.dotrack.core.ui.theme.CardColorMediumPriority
+import com.shreyash.dotrack.core.ui.theme.DoTrackTheme
+import com.shreyash.dotrack.domain.model.Priority
+import com.shreyash.dotrack.domain.model.Task
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun TaskList(
+    tasks: List<Task>,
+    onTaskClick: (String) -> Unit,
+    onTaskCheckChange: (Task, Boolean) -> Unit,
+    onDeleteTask: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier) {
+        items(tasks, key = { it.id }) { task ->
+            TaskItem(
+                task = task,
+                onClick = { onTaskClick(task.id) },
+                onCheckChange = { isCompleted -> onTaskCheckChange(task, isCompleted) },
+                onDeleteTask = onDeleteTask
+            )
+        }
+    }
+}
+
+@Composable
+fun TaskItem(
+    task: Task,
+    onClick: () -> Unit,
+    onCheckChange: (Boolean) -> Unit,
+    onDeleteTask: (String) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val dateFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm")
+    val color = when (task.priority) {
+        Priority.HIGH -> CardColorHighPriority
+        Priority.MEDIUM -> CardColorMediumPriority
+        Priority.LOW -> CardColorLowPriority
+    }
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clickable(onClick = onClick),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color)
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Checkbox(
+                checked = task.isCompleted,
+                onCheckedChange = onCheckChange
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                val isDarkTheme = isSystemInDarkTheme()
+                val textColor = if (isDarkTheme) Color.White else Color.Black
+
+                Text(
+                    text = task.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    textDecoration = if (task.isCompleted) TextDecoration.LineThrough else TextDecoration.None,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = textColor
+                )
+
+                if (task.description.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = task.description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        textDecoration = if (task.isCompleted) TextDecoration.LineThrough else TextDecoration.None,
+                        color = textColor
+                    )
+                }
+
+                task.dueDate?.let {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(R.string.due_label, it.format(dateFormatter)),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = textColor
+                    )
+                }
+            }
+
+            PriorityIndicator(
+                priority = task.priority,
+                taskId = task.id,
+                onDeleteTask = onDeleteTask
+            )
+        }
+    }
+}
+
+@Composable
+fun PriorityIndicator(
+    priority: Priority,
+    taskId: String,
+    onDeleteTask: (String) -> Unit = {}
+) {
+    val color = when (priority) {
+        Priority.HIGH -> MaterialTheme.colorScheme.error
+        Priority.MEDIUM -> MaterialTheme.colorScheme.tertiary
+        Priority.LOW -> MaterialTheme.colorScheme.primary
+    }
+
+    var showDeleteConfirmDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmDialog = false },
+            title = { Text(stringResource(R.string.delete_task)) },
+            text = { Text(stringResource(R.string.delete_task_confirm)) },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        onDeleteTask(taskId)
+                        showDeleteConfirmDialog = false
+                    }
+                ) {
+                    Text(stringResource(R.string.delete))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteConfirmDialog = false }
+                ) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    IconButton(
+        onClick = { showDeleteConfirmDialog = true }
+    ) {
+        Icon(
+            imageVector = Icons.Default.Delete,
+            contentDescription = stringResource(R.string.delete_task_content_desc),
+            tint = color
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TaskItemPreview() {
+    DoTrackTheme {
+        TaskItem(
+            task = Task(
+                id = "1",
+                title = "Complete project",
+                description = "Finish the Android project by end of week",
+                isCompleted = false,
+                dueDate = LocalDateTime.now().plusDays(2),
+                priority = Priority.HIGH,
+                categoryId = null,
+                createdAt = LocalDateTime.now(),
+                updatedAt = LocalDateTime.now()
+            ),
+            onClick = {},
+            onCheckChange = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PriorityIndicatorPreview() {
+    DoTrackTheme {
+        PriorityIndicator(
+            priority = Priority.HIGH,
+            taskId = "1"
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TaskListPreview() {
+    DoTrackTheme {
+        TaskList(
+            tasks = listOf(
+                Task(
+                    id = "1",
+                    title = "Complete project",
+                    description = "Finish the Android project by end of week",
+                    isCompleted = false,
+                    dueDate = LocalDateTime.now().plusDays(2),
+                    priority = Priority.HIGH,
+                    categoryId = null,
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now()
+                ),
+                Task(
+                    id = "2",
+                    title = "Buy groceries",
+                    description = "Milk, eggs, bread",
+                    isCompleted = true,
+                    dueDate = LocalDateTime.now(),
+                    priority = Priority.MEDIUM,
+                    categoryId = null,
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now()
+                ),
+                Task(
+                    id = "3",
+                    title = "Read book",
+                    description = "Chapter 5-7",
+                    isCompleted = true,
+                    dueDate = LocalDateTime.now(),
+                    priority = Priority.LOW,
+                    categoryId = null,
+                    createdAt = LocalDateTime.now(),
+                    updatedAt = LocalDateTime.now()
+                )
+            ),
+            onTaskClick = {},
+            onTaskCheckChange = { _, _ -> }
+        )
+    }
+}

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TaskFilterBar.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TaskFilterBar.kt
@@ -1,0 +1,85 @@
+package com.shreyash.dotrack.ui.tasks
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.shreyash.dotrack.R
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
+
+@Composable
+fun TaskFilterBar(
+    sortOption: SortOption,
+    sortDirection: SortDirection,
+    onSortClick: () -> Unit,
+    onFilterClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TextButton(onClick = onSortClick) {
+            Text(
+                text = stringResource(
+                    when (sortOption) {
+                        SortOption.DUE_DATE -> R.string.sort_due_date
+                        SortOption.PRIORITY -> R.string.sort_priority
+                        SortOption.CREATED_DATE -> R.string.sort_created_date
+                        SortOption.TITLE -> R.string.sort_title
+                    }
+                ),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+            Icon(
+                imageVector = if (sortDirection == SortDirection.ASCENDING)
+                    Icons.Default.KeyboardArrowUp
+                else
+                    Icons.Default.KeyboardArrowDown,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(start = 2.dp)
+            )
+        }
+
+        TextButton(onClick = onFilterClick) {
+            Text(
+                text = stringResource(R.string.filter_by),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TaskFilterBarPreview() {
+    MaterialTheme {
+        TaskFilterBar(
+            sortOption = SortOption.DUE_DATE,
+            sortDirection = SortDirection.ASCENDING,
+            onSortClick = {},
+            onFilterClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksScreen.kt
@@ -4,40 +4,32 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -52,20 +44,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.shreyash.dotrack.R
-import com.shreyash.dotrack.core.ui.theme.CardColorHighPriority
-import com.shreyash.dotrack.core.ui.theme.CardColorLowPriority
-import com.shreyash.dotrack.core.ui.theme.CardColorMediumPriority
+import com.shreyash.dotrack.core.ui.theme.DoTrackTheme
 import com.shreyash.dotrack.domain.model.Priority
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
 import com.shreyash.dotrack.domain.model.Task
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -73,24 +62,21 @@ fun TasksScreen(
     onTaskClick: (String) -> Unit,
     onAddTaskClick: () -> Unit,
     viewModel: TasksViewModel = hiltViewModel()
-
 ) {
-    val tasksState by viewModel.tasks.collectAsState()
+    val tasksState by viewModel.sortedTasks.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     var showDeleteConfirmDialog by remember { mutableStateOf(false) }
     var showSetWallpaperDialog by remember { mutableStateOf(false) }
+    var showSortMenu by remember { mutableStateOf(false) }
+    var showFilterSheet by remember { mutableStateOf(false) }
 
-    // Monitor wallpaper updates
     LaunchedEffect(viewModel.wallpaperUpdated) {
-        if (viewModel.wallpaperUpdated) {
-            // Wallpaper was updated
-        }
+        if (viewModel.wallpaperUpdated) { }
     }
 
     val allTasksDeleted = stringResource(R.string.all_tasks_deleted)
 
-    // Delete confirmation dialog
     if (showDeleteConfirmDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteConfirmDialog = false },
@@ -101,26 +87,20 @@ fun TasksScreen(
                     onClick = {
                         viewModel.deleteAllTask()
                         showDeleteConfirmDialog = false
-                        scope.launch {
-                            snackbarHostState.showSnackbar(allTasksDeleted)
-                        }
+                        scope.launch { snackbarHostState.showSnackbar(allTasksDeleted) }
                     }
-                ) {
-                    Text(stringResource(R.string.delete_all_tasks))
-                }
+                ) { Text(stringResource(R.string.delete_all_tasks)) }
             },
             dismissButton = {
-                TextButton(
-                    onClick = { showDeleteConfirmDialog = false }
-                ) {
+                TextButton(onClick = { showDeleteConfirmDialog = false }) {
                     Text(stringResource(R.string.cancel))
                 }
             }
         )
     }
+
     val wallpaperInProgress = stringResource(R.string.wallpaper_in_progress)
 
-    // Delete confirmation dialog
     if (showSetWallpaperDialog) {
         AlertDialog(
             onDismissRequest = { showSetWallpaperDialog = false },
@@ -131,18 +111,12 @@ fun TasksScreen(
                     onClick = {
                         viewModel.updateWallpaper()
                         showSetWallpaperDialog = false
-                        scope.launch {
-                            snackbarHostState.showSnackbar(wallpaperInProgress)
-                        }
+                        scope.launch { snackbarHostState.showSnackbar(wallpaperInProgress) }
                     }
-                ) {
-                    Text(stringResource(R.string.apply))
-                }
+                ) { Text(stringResource(R.string.apply)) }
             },
             dismissButton = {
-                TextButton(
-                    onClick = { showSetWallpaperDialog = false }
-                ) {
+                TextButton(onClick = { showSetWallpaperDialog = false }) {
                     Text(stringResource(R.string.cancel))
                 }
             }
@@ -151,100 +125,120 @@ fun TasksScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        fontWeight = FontWeight.Bold,
-                        text = stringResource(id = R.string.app_name)
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            fontWeight = FontWeight.Bold,
+                            text = stringResource(id = R.string.app_name)
+                        )
+                    },
+                    actions = {
+                        IconButton(onClick = { showSetWallpaperDialog = true }) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_wallpaper),
+                                contentDescription = stringResource(R.string.set_as_wallpaper)
+                            )
+                        }
+                        IconButton(onClick = { showDeleteConfirmDialog = true }) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = stringResource(R.string.delete_all_tasks_content_desc)
+                            )
+                        }
+                    },
+                    modifier = Modifier.statusBarsPadding()
+                )
+            },
+            floatingActionButton = {
+                FloatingActionButton(onClick = onAddTaskClick) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = stringResource(R.string.add_task)
                     )
-                },
-                actions = {
-                    IconButton(
-                        onClick = { showSetWallpaperDialog = true }
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_wallpaper),
-                            contentDescription = stringResource(R.string.set_as_wallpaper)
-                        )
+                }
+            },
+            snackbarHost = { SnackbarHost(snackbarHostState) }
+        ) { padding ->
+            Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    TaskFilterBar(
+                        sortOption = viewModel.sortOption,
+                        sortDirection = viewModel.sortDirection,
+                        onSortClick = { showSortMenu = true },
+                        onFilterClick = { showFilterSheet = true }
+                    )
+
+                    Box(modifier = Modifier.weight(1f)) {
+                    when {
+                        tasksState.isLoading() -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) { CircularProgressIndicator() }
+                        }
+
+                        tasksState.isSuccess() -> {
+                            val tasks = tasksState.getOrNull() ?: emptyList()
+                            if (tasks.isEmpty()) {
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.no_tasks_yet),
+                                        color = MaterialTheme.colorScheme.onBackground
+                                    )
+                                }
+                            } else {
+                                TaskList(
+                                    tasks = tasks,
+                                    onTaskClick = onTaskClick,
+                                    onTaskCheckChange = { task, isCompleted ->
+                                        if (isCompleted) viewModel.completeTask(task.id)
+                                        else viewModel.uncompleteTask(task.id)
+                                    },
+                                    onDeleteTask = { taskId -> viewModel.deleteTask(taskId) },
+                                    modifier = Modifier.fillMaxSize()
+                                )
+                            }
+                        }
+
+                        tasksState.isError() -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.error_format, tasksState.exceptionOrNull()?.message ?: ""),
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
+                            }
+                        }
                     }
-                    IconButton(
-                        onClick = { showDeleteConfirmDialog = true }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            contentDescription = stringResource(R.string.delete_all_tasks_content_desc)
-                        )
-                    }
-                },
-                modifier = Modifier.statusBarsPadding()
-            )
-        },
-        floatingActionButton = {
-            FloatingActionButton(onClick = onAddTaskClick) {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    contentDescription = stringResource(R.string.add_task)
+                }
+            }
+
+            if (showSortMenu) {
+                SortDropdownMenu(
+                    onDismiss = { showSortMenu = false },
+                    currentSort = viewModel.sortOption,
+                    currentDirection = viewModel.sortDirection,
+                    onSortOptionSelected = { viewModel.setSortOption(it) },
+                    onToggleDirection = { viewModel.toggleSortDirection() },
+                    onReset = { viewModel.resetSort() }
                 )
             }
-        },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
-    ) { padding ->
-        when {
-            tasksState.isLoading() -> {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(padding),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
-                }
-            }
 
-            tasksState.isSuccess() -> {
-                val tasks = tasksState.getOrNull() ?: emptyList()
-                if (tasks.isEmpty()) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(padding),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = stringResource(R.string.no_tasks_yet),
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                    }
-                } else {
-                    TaskList(
-                        tasks = tasks,
-                        onTaskClick = onTaskClick,
-                        onTaskCheckChange = { task, isCompleted ->
-                            if (isCompleted) {
-                                viewModel.completeTask(task.id)
-                            } else {
-                                viewModel.uncompleteTask(task.id)
-                            }
-                        },
-                        onDeleteTask = { taskId -> viewModel.deleteTask(taskId) },
-                        modifier = Modifier.padding(padding)
-                    )
-                }
-            }
-
-            tasksState.isError() -> {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(padding),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = stringResource(R.string.error_format, tasksState.exceptionOrNull()?.message ?: ""),
-                        color = MaterialTheme.colorScheme.onBackground
-                    )
-                }
+            if (showFilterSheet) {
+                FilterBottomSheet(
+                    onDismiss = { showFilterSheet = false },
+                    currentPriorityFilter = viewModel.filterPriority,
+                    currentStatusFilter = viewModel.filterCompleted,
+                    onPriorityFilterSelected = { viewModel.setFilterPriority(it) },
+                    onStatusFilterSelected = { viewModel.setFilterStatus(it) },
+                    onReset = { viewModel.resetFilter() }
+                )
             }
         }
     }
@@ -260,7 +254,7 @@ fun TasksScreen(
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 CircularProgressIndicator(color = Color.White)
-                Spacer(modifier = Modifier.height(16.dp))
+                androidx.compose.foundation.layout.Spacer(modifier = Modifier.height(16.dp))
                 Text(
                     text = stringResource(R.string.applying_wallpaper),
                     color = Color.White,
@@ -271,216 +265,105 @@ fun TasksScreen(
     }
 }
 
-@Composable
-fun TaskList(
-    tasks: List<Task>,
-    onTaskClick: (String) -> Unit,
-    onTaskCheckChange: (Task, Boolean) -> Unit,
-    onDeleteTask: (String) -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    LazyColumn(
-        modifier = modifier
-    ) {
-        items(tasks, key = { it.id }) { task ->
-            TaskItem(
-                task = task,
-                onClick = { onTaskClick(task.id) },
-                onCheckChange = { isCompleted -> onTaskCheckChange(task, isCompleted) },
-                onDeleteTask = onDeleteTask
-            )
-        }
-    }
-}
-
-@Composable
-fun TaskItem(
-    task: Task,
-    onClick: () -> Unit,
-    onCheckChange: (Boolean) -> Unit,
-    onDeleteTask: (String) -> Unit = {},
-    modifier: Modifier = Modifier
-) {
-    val dateFormatter = DateTimeFormatter.ofPattern("MMM dd, yyyy HH:mm")
-    val color = when (task.priority) {
-        Priority.HIGH -> CardColorHighPriority
-        Priority.MEDIUM -> CardColorMediumPriority
-        Priority.LOW -> CardColorLowPriority
-    }
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .clickable(onClick = onClick),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(color)
-                .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Checkbox(
-                checked = task.isCompleted,
-                onCheckedChange = onCheckChange
-            )
-
-            Spacer(modifier = Modifier.width(16.dp))
-
-            Column(
-                modifier = Modifier.weight(1f)
-            ) {
-                val isDarkTheme = isSystemInDarkTheme()
-                val textColor = if (isDarkTheme) Color.White else Color.Black
-                
-                Text(
-                    text = task.title,
-                    style = MaterialTheme.typography.titleMedium,
-                    textDecoration = if (task.isCompleted) TextDecoration.LineThrough else TextDecoration.None,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = textColor
-                )
-
-                if (task.description.isNotBlank()) {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = task.description,
-                        style = MaterialTheme.typography.bodyMedium,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                        textDecoration = if (task.isCompleted) TextDecoration.LineThrough else TextDecoration.None,
-                        color = textColor
-                    )
-                }
-
-                task.dueDate?.let {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = stringResource(R.string.due_label, it.format(dateFormatter)),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = textColor
-                    )
-                }
-            }
-
-            PriorityIndicator(
-                priority = task.priority,
-                taskId = task.id,
-                onDeleteTask = onDeleteTask
-            )
-        }
-    }
-}
-
-@Composable
-fun PriorityIndicator(
-    priority: Priority,
-    taskId: String,
-    onDeleteTask: (String) -> Unit = {}
-) {
-    val color = when (priority) {
-        Priority.HIGH -> MaterialTheme.colorScheme.error
-        Priority.MEDIUM -> MaterialTheme.colorScheme.tertiary
-        Priority.LOW -> MaterialTheme.colorScheme.primary
-    }
-
-    var showDeleteConfirmDialog by remember { mutableStateOf(false) }
-
-    if (showDeleteConfirmDialog) {
-        AlertDialog(
-            onDismissRequest = { showDeleteConfirmDialog = false },
-            title = { Text(stringResource(R.string.delete_task)) },
-            text = { Text(stringResource(R.string.delete_task_confirm)) },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        onDeleteTask(taskId)
-                        showDeleteConfirmDialog = false
-                    }
-                ) {
-                    Text(stringResource(R.string.delete))
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { showDeleteConfirmDialog = false }
-                ) {
-                    Text(stringResource(R.string.cancel))
-                }
-            }
-        )
-    }
-
-    IconButton(
-        onClick = {
-            showDeleteConfirmDialog = true
-        }
-    ) {
-        Icon(
-            imageVector = Icons.Default.Delete,
-            contentDescription = stringResource(R.string.delete_task_content_desc),
-            tint = color
-        )
-    }
-}
-
-
-@Preview(showBackground = true)
-@Composable
-fun TaskListPreview() {
-    MaterialTheme {
-        TaskList(
-            tasks = listOf(
-                Task(
-                    id = "1",
-                    title = "Complete project",
-                    description = "Finish the Android project by end of week",
-                    isCompleted = false,
-                    dueDate = LocalDateTime.now().plusDays(2),
-                    priority = Priority.HIGH,
-                    categoryId = null,
-                    createdAt = LocalDateTime.now(),
-                    updatedAt = LocalDateTime.now()
-                ),
-                Task(
-                    id = "2",
-                    title = "Buy groceries",
-                    description = "Milk, eggs, bread",
-                    isCompleted = true,
-                    dueDate = LocalDateTime.now(),
-                    priority = Priority.MEDIUM,
-                    categoryId = null,
-                    createdAt = LocalDateTime.now(),
-                    updatedAt = LocalDateTime.now()
-                ),
-                Task(
-                    id = "3",
-                    title = "Read book",
-                    description = "Chapter 5-7",
-                    isCompleted = true,
-                    dueDate = LocalDateTime.now(),
-                    priority = Priority.LOW,
-                    categoryId = null,
-                    createdAt = LocalDateTime.now(),
-                    updatedAt = LocalDateTime.now()
-                )
-            ),
-            onTaskClick = {},
-            onTaskCheckChange = { _, _ -> }
-        )
-    }
-}
-
 @RequiresApi(Build.VERSION_CODES.O)
-@Preview(showBackground = true)
+@Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun TasksScreenPreview() {
-    MaterialTheme {
-        TasksScreen(
-            onTaskClick = {},
-            onAddTaskClick = {}
+    DoTrackTheme {
+        TasksScreenPreviewContent()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun TasksScreenPreviewContent() {
+    val tasks = listOf(
+        Task(
+            id = "1",
+            title = "Complete project",
+            description = "Finish the Android project by end of week",
+            isCompleted = false,
+            dueDate = LocalDateTime.now().plusDays(2),
+            priority = Priority.HIGH,
+            categoryId = null,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        ),
+        Task(
+            id = "2",
+            title = "Buy groceries",
+            description = "Milk, eggs, bread",
+            isCompleted = true,
+            dueDate = LocalDateTime.now(),
+            priority = Priority.MEDIUM,
+            categoryId = null,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        ),
+        Task(
+            id = "3",
+            title = "Read book",
+            description = "Chapter 5-7",
+            isCompleted = true,
+            dueDate = LocalDateTime.now(),
+            priority = Priority.LOW,
+            categoryId = null,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
         )
+    )
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        fontWeight = FontWeight.Bold,
+                        text = stringResource(id = R.string.app_name)
+                    )
+                },
+                actions = {
+                    IconButton(onClick = {}) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_wallpaper),
+                            contentDescription = stringResource(R.string.set_as_wallpaper)
+                        )
+                    }
+                    IconButton(onClick = {}) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = stringResource(R.string.delete_all_tasks_content_desc)
+                        )
+                    }
+                },
+                modifier = Modifier.statusBarsPadding()
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {}) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = stringResource(R.string.add_task)
+                )
+            }
+        }
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            TaskFilterBar(
+                sortOption = SortOption.DUE_DATE,
+                sortDirection = SortDirection.ASCENDING,
+                onSortClick = {},
+                onFilterClick = {}
+            )
+
+            Box(modifier = Modifier.weight(1f)) {
+                TaskList(
+                    tasks = tasks,
+                    onTaskClick = {},
+                    onTaskCheckChange = { _, _ -> },
+                    onDeleteTask = {}
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
@@ -11,6 +11,9 @@ import androidx.lifecycle.viewModelScope
 import com.shreyash.dotrack.core.util.Result
 import com.shreyash.dotrack.core.util.WallpaperGenerator
 import com.shreyash.dotrack.domain.ReminderScheduler
+import com.shreyash.dotrack.domain.model.Priority
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
 import com.shreyash.dotrack.domain.model.Task
 import com.shreyash.dotrack.domain.usecase.preferences.GetAutoWallpaperEnabledUseCase
 import com.shreyash.dotrack.domain.usecase.task.CompleteTaskUseCase
@@ -21,14 +24,16 @@ import com.shreyash.dotrack.domain.usecase.task.UncompleteTaskUseCase
 import com.shreyash.dotrack.widget.TaskWidgetUpdater
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -51,6 +56,98 @@ class TasksViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = Result.Loading
         )
+
+    private val _sortOption = kotlinx.coroutines.flow.MutableStateFlow(SortOption.DUE_DATE)
+    private val _sortDirection = kotlinx.coroutines.flow.MutableStateFlow(SortDirection.ASCENDING)
+
+    val sortOption: SortOption get() = _sortOption.value
+    val sortDirection: SortDirection get() = _sortDirection.value
+
+    private val _filterPriority = kotlinx.coroutines.flow.MutableStateFlow<Priority?>(null)
+    private val _filterCompleted = kotlinx.coroutines.flow.MutableStateFlow<Boolean?>(null)
+
+    val filterPriority: Priority? get() = _filterPriority.value
+    val filterCompleted: Boolean? get() = _filterCompleted.value
+
+    val sortedTasks: StateFlow<Result<List<Task>>> = combine(
+        getTasksUseCase(),
+        _sortOption,
+        _sortDirection,
+        _filterPriority,
+        _filterCompleted
+    ) { result, option, direction, priorityFilter, completedFilter ->
+        when (result) {
+            is Result.Success -> Result.Success(
+                filterTasks(
+                    sortTasks(result.data, option, direction),
+                    priorityFilter,
+                    completedFilter
+                )
+            )
+            is Result.Error -> result
+            is Result.Loading -> result
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = Result.Loading
+    )
+
+    fun setSortOption(option: SortOption) {
+        _sortOption.value = option
+    }
+
+    fun setSortDirection(direction: SortDirection) {
+        _sortDirection.value = direction
+    }
+
+    fun toggleSortDirection() {
+        _sortDirection.value = if (_sortDirection.value == SortDirection.ASCENDING) {
+            SortDirection.DESCENDING
+        } else {
+            SortDirection.ASCENDING
+        }
+    }
+
+    fun setFilterPriority(priority: Priority?) {
+        _filterPriority.value = priority
+    }
+
+    fun setFilterStatus(completed: Boolean?) {
+        _filterCompleted.value = completed
+    }
+
+    fun resetSort() {
+        _sortOption.value = SortOption.DUE_DATE
+        _sortDirection.value = SortDirection.ASCENDING
+    }
+
+    fun resetFilter() {
+        _filterPriority.value = null
+        _filterCompleted.value = null
+    }
+
+    private fun sortTasks(tasks: List<Task>, option: SortOption, direction: SortDirection): List<Task> {
+        val sorted = when (option) {
+            SortOption.DUE_DATE -> tasks.sortedBy { it.dueDate ?: LocalDateTime.MAX }
+            SortOption.PRIORITY -> tasks.sortedByDescending { it.priority.value }
+            SortOption.CREATED_DATE -> tasks.sortedBy { it.createdAt }
+            SortOption.TITLE -> tasks.sortedBy { it.title.lowercase() }
+        }
+        return if (direction == SortDirection.DESCENDING) sorted.reversed() else sorted
+    }
+
+    private fun filterTasks(
+        tasks: List<Task>,
+        priority: Priority?,
+        completed: Boolean?
+    ): List<Task> {
+        return tasks.filter { task ->
+            val matchesPriority = priority == null || task.priority == priority
+            val matchesStatus = completed == null || task.isCompleted == completed
+            matchesPriority && matchesStatus
+        }
+    }
 
     var wallpaperUpdated by mutableStateOf(false)
         private set

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/AddEditTaskScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/AddEditTaskScreen.kt
@@ -267,10 +267,9 @@ fun TaskForm(
                     TextButton(
                         onClick = {
                             datePickerState.selectedDateMillis?.let { millis ->
-                                selectedDate = LocalDate.ofInstant(
-                                    Instant.ofEpochMilli(millis),
-                                    ZoneId.systemDefault()
-                                )
+                                selectedDate = Instant.ofEpochMilli(millis)
+                                    .atZone(ZoneId.systemDefault())
+                                    .toLocalDate()
                                 showDatePicker = false
                                 showTimePicker = true
                             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,30 @@
     <string name="date_time_format">MMM dd, yyyy HH:mm</string>
     <string name="date_format_widget">MMM dd, yyyy</string>
 
+    <!-- Appearance -->
+    <string name="appearance">Appearance</string>
+    <string name="dark_mode">Dark Mode</string>
+    <string name="dark_mode_system">System Default</string>
+    <string name="dark_mode_light">Light</string>
+    <string name="dark_mode_dark">Dark</string>
+
+    <!-- Sort -->
+    <string name="sort_by">Sort By</string>
+    <string name="sort_due_date">Due Date</string>
+    <string name="sort_priority">Priority</string>
+    <string name="sort_created_date">Created Date</string>
+    <string name="sort_title">Title</string>
+    <string name="sort_ascending">Ascending</string>
+    <string name="sort_descending">Descending</string>
+
+    <!-- Filter -->
+    <string name="filter_by">Filter By</string>
+    <string name="filter_all">All</string>
+    <string name="filter_active">Active</string>
+    <string name="filter_completed">Completed</string>
+    <string name="filter_status">Status</string>
+    <string name="reset">Reset</string>
+
     <!-- Widget -->
     <string name="priority_high">H</string>
     <string name="priority_medium">M</string>

--- a/app/src/test/java/com/shreyash/dotrack/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/shreyash/dotrack/ui/settings/SettingsViewModelTest.kt
@@ -11,13 +11,16 @@ import com.shreyash.dotrack.core.util.Result
 import com.shreyash.dotrack.core.util.WallpaperGenerator
 import com.shreyash.dotrack.domain.model.Priority
 import com.shreyash.dotrack.domain.model.Task
+import com.shreyash.dotrack.domain.model.DarkMode
 import com.shreyash.dotrack.domain.usecase.preferences.GetAutoWallpaperEnabledUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetDarkModeUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetHighPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetLowPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetMediumPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetSecondaryWallpaperColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetWallpaperColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetAutoWallpaperEnabledUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.SetDarkModeUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetHighPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetLowPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetMediumPriorityColorUseCase
@@ -65,6 +68,8 @@ class SettingsViewModelTest {
     private lateinit var setLowPriorityColorUseCase: SetLowPriorityColorUseCase
     private lateinit var wallpaperGenerator: WallpaperGenerator
     private lateinit var getTasksUseCase: GetTasksUseCase
+    private lateinit var getDarkModeUseCase: GetDarkModeUseCase
+    private lateinit var setDarkModeUseCase: SetDarkModeUseCase
 
     // Class under test
     private lateinit var viewModel: SettingsViewModel
@@ -89,9 +94,12 @@ class SettingsViewModelTest {
         setLowPriorityColorUseCase = mockk()
         wallpaperGenerator = mockk(relaxed = true)
         getTasksUseCase = mockk()
+        getDarkModeUseCase = mockk()
+        setDarkModeUseCase = mockk(relaxed = true)
 
         // Default mock behavior
         every { getAutoWallpaperEnabledUseCase() } returns flowOf(false)
+        every { getDarkModeUseCase() } returns flowOf(DarkMode.SYSTEM.value)
         every { getWallpaperColorUseCase() } returns flowOf(DEFAULT_TOP_COLOR)
         every { getSecondaryWallpaperColorUseCase() } returns flowOf(DEFAULT_TOP_COLOR)
         every { getHighPriorityColorUseCase() } returns flowOf(DEFAULT_HIGH_PRIORITY_COLOR)
@@ -114,7 +122,9 @@ class SettingsViewModelTest {
             getLowPriorityColorUseCase = getLowPriorityColorUseCase,
             setLowPriorityColorUseCase = setLowPriorityColorUseCase,
             wallpaperGenerator = wallpaperGenerator,
-            getTasksUseCase = getTasksUseCase
+            getTasksUseCase = getTasksUseCase,
+            getDarkModeUseCase = getDarkModeUseCase,
+            setDarkModeUseCase = setDarkModeUseCase
         )
     }
 
@@ -272,7 +282,9 @@ class SettingsViewModelTest {
             getLowPriorityColorUseCase = getLowPriorityColorUseCase,
             setLowPriorityColorUseCase = setLowPriorityColorUseCase,
             wallpaperGenerator = wallpaperGenerator,
-            getTasksUseCase = getTasksUseCase
+            getTasksUseCase = getTasksUseCase,
+            getDarkModeUseCase = getDarkModeUseCase,
+            setDarkModeUseCase = setDarkModeUseCase
         )
 
         // Then - show color picker should not crash

--- a/data/src/main/java/com/shreyash/dotrack/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/data/src/main/java/com/shreyash/dotrack/data/repository/UserPreferencesRepositoryImpl.kt
@@ -34,6 +34,7 @@ class UserPreferencesRepositoryImpl @Inject constructor(
         val HIGH_PRIORITY_COLOR = stringPreferencesKey("high_priority_color")
         val MEDIUM_PRIORITY_COLOR = stringPreferencesKey("medium_priority_color")
         val LOW_PRIORITY_COLOR = stringPreferencesKey("low_priority_color")
+        val DARK_MODE = stringPreferencesKey("dark_mode")
     }
 
     private val TAG = "UserPreferencesRepositoryImpl"
@@ -181,6 +182,31 @@ class UserPreferencesRepositoryImpl @Inject constructor(
         return try {
             dataStore.edit { preferences ->
                 preferences[PreferencesKeys.LOW_PRIORITY_COLOR] = colorHex
+            }
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+
+    override fun getDarkMode(): Flow<String> {
+        return dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
+            }
+            .map { preferences ->
+                preferences[PreferencesKeys.DARK_MODE] ?: "system"
+            }
+    }
+
+    override suspend fun setDarkMode(mode: String): Result<Unit> {
+        return try {
+            dataStore.edit { preferences ->
+                preferences[PreferencesKeys.DARK_MODE] = mode
             }
             Result.Success(Unit)
         } catch (e: Exception) {

--- a/domain/src/main/java/com/shreyash/dotrack/domain/model/DarkMode.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/model/DarkMode.kt
@@ -1,0 +1,13 @@
+package com.shreyash.dotrack.domain.model
+
+enum class DarkMode(val value: String) {
+    SYSTEM("system"),
+    LIGHT("light"),
+    DARK("dark");
+
+    companion object {
+        fun fromValue(value: String): DarkMode {
+            return entries.firstOrNull { it.value == value } ?: SYSTEM
+        }
+    }
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/model/SortOption.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/model/SortOption.kt
@@ -1,0 +1,13 @@
+package com.shreyash.dotrack.domain.model
+
+enum class SortOption {
+    DUE_DATE,
+    PRIORITY,
+    CREATED_DATE,
+    TITLE
+}
+
+enum class SortDirection {
+    ASCENDING,
+    DESCENDING
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/repository/UserPreferencesRepository.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/repository/UserPreferencesRepository.kt
@@ -66,4 +66,16 @@ interface UserPreferencesRepository {
      * @param colorHex A hex color string (e.g., "#DFF5E0")
      */
     suspend fun setLowPriorityColor(colorHex: String): Result<Unit>
+
+    /**
+     * Get the dark mode preference as a Flow
+     * Returns "system", "light", or "dark"
+     */
+    fun getDarkMode(): Flow<String>
+
+    /**
+     * Set the dark mode preference
+     * @param mode "system", "light", or "dark"
+     */
+    suspend fun setDarkMode(mode: String): Result<Unit>
 }

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/GetDarkModeUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/GetDarkModeUseCase.kt
@@ -1,0 +1,13 @@
+package com.shreyash.dotrack.domain.usecase.preferences
+
+import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetDarkModeUseCase @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+    operator fun invoke(): Flow<String> {
+        return userPreferencesRepository.getDarkMode()
+    }
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/SetDarkModeUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/SetDarkModeUseCase.kt
@@ -1,0 +1,13 @@
+package com.shreyash.dotrack.domain.usecase.preferences
+
+import com.shreyash.dotrack.core.util.Result
+import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
+import javax.inject.Inject
+
+class SetDarkModeUseCase @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+    suspend operator fun invoke(mode: String): Result<Unit> {
+        return userPreferencesRepository.setDarkMode(mode)
+    }
+}

--- a/whatsnew/whatsnew-en-US
+++ b/whatsnew/whatsnew-en-US
@@ -1,2 +1,5 @@
-• Bug fixes 
-• Dialog to set wallpaper 
+• Sort and filter tasks with new bottom sheets
+• Dark mode support (system/light/dark)
+• Redesigned settings screen
+• Improved date picker and time picker UI
+• Bug fixes and performance improvements


### PR DESCRIPTION
## Summary

Overhaul of sort/filter UI, dark mode support, SettingsScreen polish, and Play Store compliance fixes.

## Changes

### Sort & Filter
- Converted sort dropdown to a `ModalBottomSheet` with ripple feedback
- Added `FilterBottomSheet` with status (All/Active/Completed) and priority filters
- Decoupled sort and filter into separate controls on `TaskFilterBar` (sort left, filter right)
- Added reset buttons to both sheets
- Changed TaskFilterBar from pill buttons to clickable text (TextButton)

### Dark Mode
- New `DarkMode` enum (System/Light/Dark)
- `GetDarkModeUseCase` / `SetDarkModeUseCase` for preferences persistence
- Settings screen dark mode picker
- `ThemeViewModel` for reactive theme switching

### SettingsScreen Polish
- Complete rewrite with consistent spacing (Arrangement.spacedBy)
- Extracted `SectionCard`, `SectionDivider`, `SectionHeader` helpers
- Removed double padding and card boilerplate
- Fixed preview crash (hiltViewModel moved inside function body)
- Added "Primary"/"Secondary" string resources

### Play Store Compliance
- Fixed edge-to-edge: outer Scaffold only consumes bottom insets, TopAppBar uses statusBarsPadding
- Removed deprecated `WindowCompat.getInsetsController` in Theme.kt
- Enabled R8 full mode in gradle.properties
- Bumped compileSdk/targetSdk to 36 (API 36 compliant)
- `build_bundle.yml` now runs lint before building

### Bug Fixes
- Fixed `LocalDate.ofInstant` crash on API < 34 in date picker
- Fixed `SettingsViewModelTest` missing dark mode constructor params

### Code Quality
- All 206 unit tests pass
- Zero lint errors
- Release build compiles cleanly