### PR TITLE
Fix R8 optimization, reminder scheduling, and persist sort preference

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,157 +1,65 @@
-# DoTrack App ProGuard Rules
+# DoTrack App ProGuard Rules (R8 full mode)
+#
+# Strategy: keep ONLY what reflection/codegen needs at runtime.
+# All libraries below ship their own correct consumer rules inside their AARs
+# and must NOT be blanket-kept here:
+#   - Jetpack Compose / Navigation / Lifecycle / WorkManager
+#   - Hilt / Dagger
+#   - Room (runtime + compiler generated references)
+#   - Kotlin Coroutines
+# Everything else is shrunk and obfuscated by R8 full mode.
 
-# Keep line numbers for debugging
+# ================================
+# Stack traces
+# ================================
 -keepattributes SourceFile,LineNumberTable
 -renamesourcefileattribute SourceFile
-
-# Keep generic signatures for reflection
--keepattributes Signature
 -keepattributes *Annotation*
--keepattributes EnclosingMethod
--keepattributes InnerClasses
 
 # ================================
-# Kotlin Coroutines
+# @Keep annotation support
 # ================================
--keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
--keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
--keepclassmembers class kotlinx.coroutines.** {
-    volatile <fields>;
+-keep @androidx.annotation.Keep class * { *; }
+-keepclassmembers class * {
+    @androidx.annotation.Keep *;
 }
--keepclassmembers class kotlin.coroutines.SafeContinuation {
-    volatile <fields>;
+-keepclasseswithmembers class * {
+    @androidx.annotation.Keep <methods>;
 }
 
 # ================================
-# Jetpack Compose
+# Room
+# (generated _Impl classes are covered by Room's own consumer rules;
+#  keep only the database and entities that map to SQLite tables)
 # ================================
--keep class androidx.compose.** { *; }
--keep class androidx.compose.runtime.** { *; }
--keep class androidx.compose.ui.** { *; }
--keep class androidx.compose.material3.** { *; }
--keep class androidx.compose.foundation.** { *; }
--keep class androidx.compose.animation.** { *; }
-
-# Keep Composable functions
--keep @androidx.compose.runtime.Composable class * {
-    *;
-}
-
-# Keep classes with @Composable methods
--keep class * {
-    @androidx.compose.runtime.Composable *;
-}
-
-# ================================
-# Hilt / Dagger
-# ================================
--keep class dagger.** { *; }
--keep class javax.inject.** { *; }
--keep class dagger.hilt.** { *; }
-
-# Keep Hilt generated classes
--keep class **_HiltModules { *; }
--keep class **_HiltModules$* { *; }
--keep class **_Provide* { *; }
--keep class **_Factory { *; }
--keep class **_MembersInjector { *; }
-
-# Keep classes annotated with Hilt annotations
--keep @dagger.hilt.android.lifecycle.HiltViewModel class * { *; }
--keep @dagger.Module class * { *; }
--keep @dagger.hilt.InstallIn class * { *; }
--keep @javax.inject.Inject class * { *; }
-
-# Keep Hilt entry points
--keep @dagger.hilt.android.HiltAndroidApp class * { *; }
-
-# ================================
-# Room Database
-# ================================
--keep class androidx.room.** { *; }
--keep class androidx.sqlite.** { *; }
-
-# Keep Room entities and DAOs
+-keep class * extends androidx.room.RoomDatabase { *; }
 -keep @androidx.room.Entity class * { *; }
--keep @androidx.room.Dao class * { *; }
--keep @androidx.room.Database class * { *; }
-
-# Keep Room generated classes
--keep class **_Impl { *; }
--keep class **_Impl$* { *; }
 
 # ================================
 # WorkManager
+# Workers are instantiated via reflection with (Context, WorkerParameters)
 # ================================
--keep class androidx.work.** { *; }
--keep class * extends androidx.work.Worker { *; }
--keep class * extends androidx.work.ListenableWorker { *; }
-
-# Keep Worker classes
--keep class com.shreyash.dotrack.core.worker.** { *; }
-
-# ================================
-# Navigation Component
-# ================================
--keep class androidx.navigation.** { *; }
--keepclassmembers class * extends androidx.navigation.NavArgs {
-    *;
+-keep class * extends androidx.work.ListenableWorker {
+    <init>(android.content.Context, androidx.work.WorkerParameters);
 }
 
 # ================================
-# Lifecycle Components
+# Hilt
+# ViewModels are constructed reflectively by Hilt/SavedStateViewModelFactory
 # ================================
--keep class androidx.lifecycle.** { *; }
--keep class * extends androidx.lifecycle.ViewModel { *; }
--keep class * extends androidx.lifecycle.AndroidViewModel { *; }
-
-# ================================
-# Color Picker Library
-# ================================
--keep class com.github.skydoves.colorpicker.** { *; }
+-keep @dagger.hilt.android.lifecycle.HiltViewModel class * {
+    <init>(...);
+}
+-keep class dagger.hilt.android.internal.lifecycle.ViewComponentManager { *; }
 
 # ================================
-# Gson (if used)
+# Parcelable / Serializable support classes
+# (system framework may marshal these across processes)
 # ================================
--keepattributes Signature
--keepattributes *Annotation*
--keep class sun.misc.Unsafe { *; }
--keep class com.google.gson.** { *; }
-
-# ================================
-# App-specific classes
-# ================================
-
-# Keep domain models
--keep class com.shreyash.dotrack.domain.model.** { *; }
-
-# Keep data entities
--keep class com.shreyash.dotrack.data.local.entity.** { *; }
-
-# Keep use cases
--keep class com.shreyash.dotrack.domain.usecase.** { *; }
-
-# Keep repositories
--keep class com.shreyash.dotrack.domain.repository.** { *; }
--keep class com.shreyash.dotrack.data.repository.** { *; }
-
-# Keep ViewModels
--keep class com.shreyash.dotrack.ui.**.ViewModel { *; }
--keep class com.shreyash.dotrack.ui.**.*ViewModel { *; }
-
-# Keep Hilt modules
--keep class com.shreyash.dotrack.di.** { *; }
-
-# Keep enum classes
--keep enum com.shreyash.dotrack.** { *; }
-
-# Keep Parcelable classes
 -keep class * implements android.os.Parcelable {
     public static final android.os.Parcelable$Creator *;
 }
-
-# Keep Serializable classes
--keep class * implements java.io.Serializable {
+-keepclassmembers class * implements java.io.Serializable {
     static final long serialVersionUID;
     private static final java.io.ObjectStreamField[] serialPersistentFields;
     private void writeObject(java.io.ObjectOutputStream);
@@ -161,41 +69,8 @@
 }
 
 # ================================
-# Android Components
-# ================================
-
-# Keep Activities, Services, Receivers
--keep public class * extends android.app.Activity
--keep public class * extends android.app.Application
--keep public class * extends android.app.Service
--keep public class * extends android.content.BroadcastReceiver
--keep public class * extends android.content.ContentProvider
-
-# Keep custom views
--keep public class * extends android.view.View {
-    public <init>(android.content.Context);
-    public <init>(android.content.Context, android.util.AttributeSet);
-    public <init>(android.content.Context, android.util.AttributeSet, int);
-}
-
-# ================================
-# Reflection and Native Methods
-# ================================
-
-# Keep native methods
--keepclasseswithmembernames class * {
-    native <methods>;
-}
-
-# Keep classes with reflection
--keepclassmembers class * {
-    @androidx.annotation.Keep *;
-}
-
-# ================================
 # Remove Logging in Release Builds
 # ================================
-# Remove all Log statements in release builds for better performance and security
 -assumenosideeffects class android.util.Log {
     public static boolean isLoggable(java.lang.String, int);
     public static int v(...);
@@ -204,19 +79,3 @@
     public static int d(...);
     public static int e(...);
 }
-
-# ================================
-# Optimization Settings
-# ================================
-
-# Enable aggressive optimizations
--optimizations !code/simplification/arithmetic,!code/simplification/cast,!field/*,!class/merging/*
--optimizationpasses 5
--allowaccessmodification
--dontpreverify
-
-# Don't warn about missing classes (common with optional dependencies)
--dontwarn java.lang.invoke.**
--dontwarn javax.annotation.**
--dontwarn javax.inject.**
--dontwarn sun.misc.Unsafe

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksScreen.kt
@@ -1,19 +1,29 @@
 package com.shreyash.dotrack.ui.tasks
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -23,6 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -39,6 +50,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -48,6 +60,7 @@ import com.shreyash.dotrack.domain.model.Priority
 import com.shreyash.dotrack.domain.model.SortDirection
 import com.shreyash.dotrack.domain.model.SortOption
 import com.shreyash.dotrack.domain.model.Task
+import com.shreyash.dotrack.domain.model.TaskDeleteScope
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 
@@ -59,6 +72,7 @@ fun TasksScreen(
     viewModel: TasksViewModel = hiltViewModel()
 ) {
     val tasksState by viewModel.sortedTasks.collectAsState()
+    val taskCounts by viewModel.taskCounts.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     var showDeleteConfirmDialog by remember { mutableStateOf(false) }
@@ -66,27 +80,110 @@ fun TasksScreen(
     var showSortMenu by remember { mutableStateOf(false) }
     var showFilterSheet by remember { mutableStateOf(false) }
 
-    val allTasksDeleted = stringResource(R.string.all_tasks_deleted)
+    val allTasksDeleted = stringResource(R.string.tasks_deleted)
 
     if (showDeleteConfirmDialog) {
+        var selectedDeleteScopes by remember { mutableStateOf(setOf<TaskDeleteScope>()) }
+
         AlertDialog(
             onDismissRequest = { showDeleteConfirmDialog = false },
-            title = { Text(stringResource(R.string.delete_all_tasks)) },
-            text = { Text(stringResource(R.string.delete_all_confirm)) },
+            title = {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.delete_tasks_title),
+                        fontWeight = FontWeight.Bold
+                    )
+                    IconButton(onClick = { showDeleteConfirmDialog = false }) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(R.string.close)
+                        )
+                    }
+                }
+            },
+            text = {
+                Column {
+                    Text(
+                        text = stringResource(R.string.delete_tasks_summary, taskCounts.total),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        DeleteScopeOption(
+                            label = stringResource(R.string.delete_completed_tasks),
+                            count = taskCounts.completed,
+                            checked = TaskDeleteScope.COMPLETED in selectedDeleteScopes,
+                            enabled = taskCounts.completed > 0,
+                            onClick = {
+                                selectedDeleteScopes = toggleDeleteScope(
+                                    selectedDeleteScopes,
+                                    TaskDeleteScope.COMPLETED
+                                )
+                            },
+                            modifier = Modifier.weight(1f)
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        DeleteScopeOption(
+                            label = stringResource(R.string.delete_incomplete_tasks),
+                            count = taskCounts.incomplete,
+                            checked = TaskDeleteScope.INCOMPLETE in selectedDeleteScopes,
+                            enabled = taskCounts.incomplete > 0,
+                            onClick = {
+                                selectedDeleteScopes = toggleDeleteScope(
+                                    selectedDeleteScopes,
+                                    TaskDeleteScope.INCOMPLETE
+                                )
+                            },
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+            },
             confirmButton = {
                 Button(
                     onClick = {
-                        viewModel.deleteCompletedTasks()
+                        if (TaskDeleteScope.COMPLETED in selectedDeleteScopes &&
+                            TaskDeleteScope.INCOMPLETE in selectedDeleteScopes
+                        ) {
+                            viewModel.deleteTasks(TaskDeleteScope.ALL)
+                        } else {
+                            selectedDeleteScopes.forEach { scope ->
+                                viewModel.deleteTasks(scope)
+                            }
+                        }
                         showDeleteConfirmDialog = false
                         scope.launch { snackbarHostState.showSnackbar(allTasksDeleted) }
-                    }
-                ) { Text(stringResource(R.string.delete_all_tasks)) }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDeleteConfirmDialog = false }) {
-                    Text(stringResource(R.string.cancel))
+                    },
+                    enabled = selectedDeleteScopes.isNotEmpty(),
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                        disabledContainerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.38f)
+                    )
+                ) {
+                    Text(
+                        text = when {
+                            TaskDeleteScope.COMPLETED in selectedDeleteScopes &&
+                                TaskDeleteScope.INCOMPLETE in selectedDeleteScopes -> {
+                                stringResource(R.string.delete_all_tasks)
+                            }
+                            TaskDeleteScope.COMPLETED in selectedDeleteScopes -> {
+                                stringResource(R.string.delete_completed_action)
+                            }
+                            TaskDeleteScope.INCOMPLETE in selectedDeleteScopes -> {
+                                stringResource(R.string.delete_incomplete_action)
+                            }
+                            else -> stringResource(R.string.delete_all_tasks)
+                        }
+                    )
                 }
-            }
+            },
+            dismissButton = {}
         )
     }
 
@@ -372,6 +469,88 @@ internal fun TasksScreenPreviewContent() {
                     onTaskClick = {},
                     onTaskCheckChange = { _, _ -> },
                     onDeleteTask = {}
+                )
+            }
+        }
+    }
+}
+private fun toggleDeleteScope(
+    scopes: Set<TaskDeleteScope>,
+    scope: TaskDeleteScope
+): Set<TaskDeleteScope> {
+    return if (scope in scopes) scopes - scope else scopes + scope
+}
+
+@Composable
+private fun DeleteScopeOption(
+    label: String,
+    count: Int,
+    checked: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val isDimmed = !enabled
+    val borderColor = when {
+        isDimmed -> MaterialTheme.colorScheme.outlineVariant
+        checked -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.outlineVariant
+    }
+    Surface(
+        onClick = { if (enabled) onClick() },
+        modifier = modifier,
+        shape = RoundedCornerShape(12.dp),
+        border = BorderStroke(
+            width = if (checked) 2.dp else 1.dp,
+            color = borderColor
+        ),
+        color = when {
+            isDimmed -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+            checked -> MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
+            else -> MaterialTheme.colorScheme.surface
+        }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 18.dp, horizontal = 10.dp)
+        ) {
+            if (checked) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .size(18.dp)
+                )
+            }
+            Column(
+                modifier = Modifier.align(Alignment.Center),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = if (checked) FontWeight.Bold else FontWeight.Medium,
+                    color = if (isDimmed) {
+                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = count.toString(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (isDimmed) {
+                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
+                    } else if (checked) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    }
                 )
             }
         }

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
@@ -14,6 +14,7 @@ import com.shreyash.dotrack.domain.model.Priority
 import com.shreyash.dotrack.domain.model.SortDirection
 import com.shreyash.dotrack.domain.model.SortOption
 import com.shreyash.dotrack.domain.model.Task
+import com.shreyash.dotrack.domain.model.TaskDeleteScope
 import com.shreyash.dotrack.domain.usecase.preferences.GetAutoWallpaperEnabledUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetSortDirectionUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetSortOptionUseCase
@@ -21,6 +22,7 @@ import com.shreyash.dotrack.domain.usecase.preferences.SetSortDirectionUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetSortOptionUseCase
 import com.shreyash.dotrack.domain.usecase.task.CompleteTaskUseCase
 import com.shreyash.dotrack.domain.usecase.task.DeleteTaskUseCase
+import com.shreyash.dotrack.domain.usecase.task.DeleteTasksUseCase
 import com.shreyash.dotrack.domain.usecase.task.DisableReminderUseCase
 import com.shreyash.dotrack.domain.usecase.task.GetTasksUseCase
 import com.shreyash.dotrack.domain.usecase.task.UncompleteTaskUseCase
@@ -34,6 +36,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -48,6 +51,7 @@ class TasksViewModel @Inject constructor(
     private val uncompleteTaskUseCase: UncompleteTaskUseCase,
     private val wallpaperGenerator: WallpaperGenerator,
     private val deleteTaskUseCase: DeleteTaskUseCase,
+    private val deleteTasksUseCase: DeleteTasksUseCase,
     private val getAutoWallpaperEnabledUseCase: GetAutoWallpaperEnabledUseCase,
     private val disableReminderUseCase: DisableReminderUseCase,
     private val reminderScheduler: ReminderScheduler,
@@ -114,6 +118,20 @@ class TasksViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = Result.Loading
     )
+
+    val taskCounts: StateFlow<TaskCounts> = getTasksUseCase()
+        .map { result ->
+            val tasks = result.getOrNull().orEmpty()
+            TaskCounts(
+                completed = tasks.count { it.isCompleted },
+                incomplete = tasks.count { !it.isCompleted }
+            )
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = TaskCounts()
+        )
 
     fun setSortOption(option: SortOption) {
         sortOptionSelectedByUser = true
@@ -299,13 +317,27 @@ class TasksViewModel @Inject constructor(
     }
 
     /**
-     * Delete all tasks
+     * Delete tasks by scope (all, completed, or incomplete)
+     * Cancels pending reminders for the affected tasks
      */
-    fun deleteCompletedTasks() {
+    fun deleteTasks(scope: TaskDeleteScope) {
         isDeleting = true
         val deleteStartTime = System.currentTimeMillis()
         viewModelScope.launch(Dispatchers.IO) {
-            val result = deleteTaskUseCase()
+            val tasksResult = getTasksUseCase().first()
+            if (tasksResult.isSuccess()) {
+                val affectedTasks = tasksResult.getOrNull()?.filter { task ->
+                    when (scope) {
+                        TaskDeleteScope.ALL -> true
+                        TaskDeleteScope.COMPLETED -> task.isCompleted
+                        TaskDeleteScope.INCOMPLETE -> !task.isCompleted
+                    }
+                }.orEmpty()
+                affectedTasks.forEach { task ->
+                    reminderScheduler.cancelReminder(task.id)
+                }
+            }
+            val result = deleteTasksUseCase(scope)
             if (result.isSuccess()) {
                 val autoWallpaperEnabled = getAutoWallpaperEnabledUseCase().first()
                 if (autoWallpaperEnabled) {
@@ -325,4 +357,11 @@ class TasksViewModel @Inject constructor(
             }
         }
     }
+}
+
+data class TaskCounts(
+    val completed: Int = 0,
+    val incomplete: Int = 0
+) {
+    val total: Int get() = completed + incomplete
 }

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
@@ -15,6 +15,10 @@ import com.shreyash.dotrack.domain.model.SortDirection
 import com.shreyash.dotrack.domain.model.SortOption
 import com.shreyash.dotrack.domain.model.Task
 import com.shreyash.dotrack.domain.usecase.preferences.GetAutoWallpaperEnabledUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetSortDirectionUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetSortOptionUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.SetSortDirectionUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.SetSortOptionUseCase
 import com.shreyash.dotrack.domain.usecase.task.CompleteTaskUseCase
 import com.shreyash.dotrack.domain.usecase.task.DeleteTaskUseCase
 import com.shreyash.dotrack.domain.usecase.task.DisableReminderUseCase
@@ -28,6 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -45,7 +50,11 @@ class TasksViewModel @Inject constructor(
     private val deleteTaskUseCase: DeleteTaskUseCase,
     private val getAutoWallpaperEnabledUseCase: GetAutoWallpaperEnabledUseCase,
     private val disableReminderUseCase: DisableReminderUseCase,
-    private val reminderScheduler: ReminderScheduler
+    private val reminderScheduler: ReminderScheduler,
+    private val getSortOptionUseCase: GetSortOptionUseCase,
+    private val setSortOptionUseCase: SetSortOptionUseCase,
+    private val getSortDirectionUseCase: GetSortDirectionUseCase,
+    private val setSortDirectionUseCase: SetSortDirectionUseCase
 ) : ViewModel() {
 
     private val TAG = "TasksViewModel"
@@ -55,6 +64,26 @@ class TasksViewModel @Inject constructor(
 
     val sortOption: SortOption get() = _sortOption.value
     val sortDirection: SortDirection get() = _sortDirection.value
+
+    private var sortOptionSelectedByUser = false
+    private var sortDirectionSelectedByUser = false
+
+    init {
+        viewModelScope.launch {
+            getSortOptionUseCase()
+                .distinctUntilChanged()
+                .collect { saved ->
+                    if (!sortOptionSelectedByUser) _sortOption.value = saved
+                }
+        }
+        viewModelScope.launch {
+            getSortDirectionUseCase()
+                .distinctUntilChanged()
+                .collect { saved ->
+                    if (!sortDirectionSelectedByUser) _sortDirection.value = saved
+                }
+        }
+    }
 
     private val _filterPriority = kotlinx.coroutines.flow.MutableStateFlow<Priority?>(null)
     private val _filterCompleted = kotlinx.coroutines.flow.MutableStateFlow<Boolean?>(null)
@@ -87,18 +116,31 @@ class TasksViewModel @Inject constructor(
     )
 
     fun setSortOption(option: SortOption) {
+        sortOptionSelectedByUser = true
         _sortOption.value = option
+        viewModelScope.launch {
+            setSortOptionUseCase(option)
+        }
     }
 
     fun setSortDirection(direction: SortDirection) {
+        sortDirectionSelectedByUser = true
         _sortDirection.value = direction
+        viewModelScope.launch {
+            setSortDirectionUseCase(direction)
+        }
     }
 
     fun toggleSortDirection() {
-        _sortDirection.value = if (_sortDirection.value == SortDirection.ASCENDING) {
+        sortDirectionSelectedByUser = true
+        val newDirection = if (_sortDirection.value == SortDirection.ASCENDING) {
             SortDirection.DESCENDING
         } else {
             SortDirection.ASCENDING
+        }
+        _sortDirection.value = newDirection
+        viewModelScope.launch {
+            setSortDirectionUseCase(newDirection)
         }
     }
 
@@ -111,8 +153,14 @@ class TasksViewModel @Inject constructor(
     }
 
     fun resetSort() {
+        sortOptionSelectedByUser = true
+        sortDirectionSelectedByUser = true
         _sortOption.value = SortOption.DUE_DATE
         _sortDirection.value = SortDirection.ASCENDING
+        viewModelScope.launch {
+            setSortOptionUseCase(SortOption.DUE_DATE)
+            setSortDirectionUseCase(SortDirection.ASCENDING)
+        }
     }
 
     fun resetFilter() {

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/AddEditTaskViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/addedit/AddEditTaskViewModel.kt
@@ -131,16 +131,24 @@ class AddEditTaskViewModel @Inject constructor(
         val saveStartTime = System.currentTimeMillis()
 
         viewModelScope.launch(Dispatchers.IO) {
+            val newTaskId: String?
             val result = if (uiState.id == null) {
                 // Add new task
-                addTaskUseCase(
+                val created = addTaskUseCase(
                     title = uiState.title,
                     description = uiState.description,
                     dueDate = uiState.dueDate,
                     priority = uiState.priority,
                     reminderEnabled = uiState.reminderEnabled
                 )
+                newTaskId = created.getOrNull()
+                when (created) {
+                    is Result.Success -> Result.success(Unit)
+                    is Result.Error -> created
+                    is Result.Loading -> Result.loading()
+                }
             } else {
+                newTaskId = null
                 // Update existing task
                 val now = LocalDateTime.now()
                 val task = Task(
@@ -158,7 +166,7 @@ class AddEditTaskViewModel @Inject constructor(
             }
 
             if (result.isSuccess()) {
-                val savedTaskId = uiState.id
+                val savedTaskId = uiState.id ?: newTaskId
                 val savedDueDate = uiState.dueDate
                 // Update wallpaper with the latest task list
                 updateWallpaper()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="apply">Apply</string>
     <string name="delete">Delete</string>
     <string name="back">Back</string>
+    <string name="close">Close</string>
     <string name="save">Save</string>
 
     <!-- Time Picker -->
@@ -18,10 +19,15 @@
     <string name="edit_task">Edit Task</string>
     <string name="save_task">Save Task</string>
     <string name="delete_task">Delete Task</string>
-    <string name="delete_all_tasks">Clear Completed</string>
-    <string name="delete_all_confirm">Are you sure you want to clear all completed tasks? This action cannot be undone.</string>
+    <string name="delete_tasks_title">Delete Tasks</string>
+    <string name="delete_tasks_summary">%1$d tasks · This action cannot be undone.</string>
+    <string name="delete_all_tasks">Delete All Tasks</string>
+    <string name="delete_completed_tasks">Completed</string>
+    <string name="delete_incomplete_tasks">Incomplete</string>
+    <string name="delete_completed_action">Delete Completed</string>
+    <string name="delete_incomplete_action">Delete Incomplete</string>
     <string name="delete_task_confirm">Are you sure you want to delete this task?</string>
-    <string name="all_tasks_deleted">Completed tasks cleared</string>
+    <string name="tasks_deleted">Tasks deleted</string>
     <string name="no_tasks_yet">No tasks yet. Add one!</string>
     <string name="set_wallpaper">Set Wallpaper</string>
     <string name="set_wallpaper_confirm">Are you sure you want set wallpaper? This action cannot be undone.</string>
@@ -29,7 +35,7 @@
     <string name="applying_wallpaper">Applying wallpaper…</string>
     <string name="deleting_task">Deleting task…</string>
     <string name="set_as_wallpaper">Set as Wallpaper</string>
-    <string name="delete_all_tasks_content_desc">Clear completed tasks</string>
+    <string name="delete_all_tasks_content_desc">Delete tasks</string>
     <string name="error_format">Error: %s</string>
     <string name="due_label">Due: %s</string>
     <string name="delete_task_content_desc">Delete task</string>

--- a/core/consumer-rules.pro
+++ b/core/consumer-rules.pro
@@ -1,26 +1,5 @@
 # Core Module Consumer ProGuard Rules
-
-# Keep all public classes and methods in the core module
--keep public class com.shreyash.dotrack.core.** { *; }
-
-# Keep UI theme classes
--keep class com.shreyash.dotrack.core.ui.theme.** { *; }
-
-# Keep UI components
--keep class com.shreyash.dotrack.core.ui.components.** { *; }
-
-# Keep utility classes
--keep class com.shreyash.dotrack.core.util.** { *; }
-
-# Keep worker classes
--keep class com.shreyash.dotrack.core.worker.** { *; }
-
-# Keep Compose-related classes
--keep @androidx.compose.runtime.Composable class * {
-    *;
-}
-
-# Keep classes with @Composable methods
--keep class * {
-    @androidx.compose.runtime.Composable *;
-}
+#
+# This module contains only theme, Result, and dispatcher utilities that are
+# referenced directly. R8 can freely shrink, inline, and obfuscate these
+# classes.

--- a/data/consumer-rules.pro
+++ b/data/consumer-rules.pro
@@ -1,41 +1,12 @@
 # Data Module Consumer ProGuard Rules
-
-# Keep all data entities
--keep class com.shreyash.dotrack.data.local.entity.** { *; }
-
-# Keep all DAOs
--keep interface com.shreyash.dotrack.data.local.dao.** { *; }
-
-# Keep database classes
--keep class com.shreyash.dotrack.data.local.database.** { *; }
-
-# Keep repository implementations
--keep class com.shreyash.dotrack.data.repository.** { *; }
-
-# Keep data sources
--keep class com.shreyash.dotrack.data.local.** { *; }
--keep class com.shreyash.dotrack.data.remote.** { *; }
-
-# Keep mappers
--keep class com.shreyash.dotrack.data.mapper.** { *; }
-
-# Room specific rules
+#
+# Only Room requires keep rules here:
+#  - @Entity classes are inspected reflectively by Room's TableInfo at runtime
+#    (field names must survive), so they must not be shrunk or obfuscated.
+#  - RoomDatabase subclasses (including the generated *_Impl) are loaded via
+#    Class.forName, so their names and constructors must survive.
+#
+# DAO interfaces, repositories, mappers, and DataStore code are all referenced
+# directly and are safely shrinkable/obfuscatable.
 -keep @androidx.room.Entity class * { *; }
--keep @androidx.room.Dao class * { *; }
--keep @androidx.room.Database class * { *; }
-
-# Keep Room generated classes
--keep class **_Impl { *; }
--keep class **_Impl$* { *; }
-
-# DataStore rules
--keep class androidx.datastore.** { *; }
-
-# Retrofit and Moshi rules
--keep class retrofit2.** { *; }
--keep class com.squareup.moshi.** { *; }
-
-# Keep classes annotated with Hilt
--keep @javax.inject.Inject class * { *; }
--keep @dagger.Module class * { *; }
--keep @dagger.hilt.InstallIn class * { *; }
+-keep class * extends androidx.room.RoomDatabase { *; }

--- a/data/src/main/java/com/shreyash/dotrack/data/local/dao/TaskDao.kt
+++ b/data/src/main/java/com/shreyash/dotrack/data/local/dao/TaskDao.kt
@@ -49,8 +49,14 @@ interface TaskDao {
     @Query("DELETE FROM tasks WHERE id = :id")
     suspend fun deleteTask(id: String)
 
+    @Query("DELETE FROM tasks")
+    suspend fun deleteAllTasks()
+
     @Query("DELETE FROM tasks WHERE isCompleted = 1")
-    suspend fun deleteAllTask()
+    suspend fun deleteCompletedTasks()
+
+    @Query("DELETE FROM tasks WHERE isCompleted = 0")
+    suspend fun deleteIncompleteTasks()
     
     @Query("UPDATE tasks SET isCompleted = 1 WHERE id = :id")
     suspend fun completeTask(id: String)

--- a/data/src/main/java/com/shreyash/dotrack/data/repository/TaskRepositoryImpl.kt
+++ b/data/src/main/java/com/shreyash/dotrack/data/repository/TaskRepositoryImpl.kt
@@ -81,9 +81,27 @@ class TaskRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deleteAllTask(): Result<Unit> = withContext(ioDispatcher) {
+    override suspend fun deleteAllTasks(): Result<Unit> = withContext(ioDispatcher) {
         return@withContext try {
-            taskDao.deleteAllTask()
+            taskDao.deleteAllTasks()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.error(e)
+        }
+    }
+
+    override suspend fun deleteCompletedTasks(): Result<Unit> = withContext(ioDispatcher) {
+        return@withContext try {
+            taskDao.deleteCompletedTasks()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.error(e)
+        }
+    }
+
+    override suspend fun deleteIncompleteTasks(): Result<Unit> = withContext(ioDispatcher) {
+        return@withContext try {
+            taskDao.deleteIncompleteTasks()
             Result.success(Unit)
         } catch (e: Exception) {
             Result.error(e)

--- a/data/src/main/java/com/shreyash/dotrack/data/repository/TaskRepositoryImpl.kt
+++ b/data/src/main/java/com/shreyash/dotrack/data/repository/TaskRepositoryImpl.kt
@@ -46,7 +46,7 @@ class TaskRepositoryImpl @Inject constructor(
         priority: Priority,
         reminderEnabled: Boolean,
         categoryId: String?
-    ): Result<Unit> = withContext(ioDispatcher) {
+    ): Result<String> = withContext(ioDispatcher) {
         return@withContext try {
             val task = TaskEntity.createNew(
                 title = title,
@@ -57,7 +57,7 @@ class TaskRepositoryImpl @Inject constructor(
                 categoryId = categoryId
             )
             taskDao.insertTask(task)
-            Result.success(Unit)
+            Result.success(task.id)
         } catch (e: Exception) {
             Result.error(e)
         }

--- a/data/src/main/java/com/shreyash/dotrack/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/data/src/main/java/com/shreyash/dotrack/data/repository/UserPreferencesRepositoryImpl.kt
@@ -13,6 +13,8 @@ import com.shreyash.dotrack.core.ui.theme.DEFAULT_LOW_PRIORITY_COLOR
 import com.shreyash.dotrack.core.ui.theme.DEFAULT_MEDIUM_PRIORITY_COLOR
 import com.shreyash.dotrack.core.ui.theme.DEFAULT_TOP_COLOR
 import com.shreyash.dotrack.core.util.Result
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
 import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -35,6 +37,8 @@ class UserPreferencesRepositoryImpl @Inject constructor(
         val MEDIUM_PRIORITY_COLOR = stringPreferencesKey("medium_priority_color")
         val LOW_PRIORITY_COLOR = stringPreferencesKey("low_priority_color")
         val DARK_MODE = stringPreferencesKey("dark_mode")
+        val SORT_OPTION = stringPreferencesKey("sort_option")
+        val SORT_DIRECTION = stringPreferencesKey("sort_direction")
     }
 
     private val TAG = "UserPreferencesRepositoryImpl"
@@ -207,6 +211,60 @@ class UserPreferencesRepositoryImpl @Inject constructor(
         return try {
             dataStore.edit { preferences ->
                 preferences[PreferencesKeys.DARK_MODE] = mode
+            }
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+
+    override fun getSortOption(): Flow<SortOption> {
+        return dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
+            }
+            .map { preferences ->
+                preferences[PreferencesKeys.SORT_OPTION]?.let { stored ->
+                    SortOption.entries.firstOrNull { it.name == stored }
+                } ?: SortOption.DUE_DATE
+            }
+    }
+
+    override suspend fun setSortOption(option: SortOption): Result<Unit> {
+        return try {
+            dataStore.edit { preferences ->
+                preferences[PreferencesKeys.SORT_OPTION] = option.name
+            }
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+
+    override fun getSortDirection(): Flow<SortDirection> {
+        return dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
+            }
+            .map { preferences ->
+                preferences[PreferencesKeys.SORT_DIRECTION]?.let { stored ->
+                    SortDirection.entries.firstOrNull { it.name == stored }
+                } ?: SortDirection.ASCENDING
+            }
+    }
+
+    override suspend fun setSortDirection(direction: SortDirection): Result<Unit> {
+        return try {
+            dataStore.edit { preferences ->
+                preferences[PreferencesKeys.SORT_DIRECTION] = direction.name
             }
             Result.Success(Unit)
         } catch (e: Exception) {

--- a/domain/consumer-rules.pro
+++ b/domain/consumer-rules.pro
@@ -1,22 +1,5 @@
 # Domain Module Consumer ProGuard Rules
-
-# Keep all domain models
--keep class com.shreyash.dotrack.domain.model.** { *; }
-
-# Keep all repositories interfaces
--keep interface com.shreyash.dotrack.domain.repository.** { *; }
-
-# Keep all use cases
--keep class com.shreyash.dotrack.domain.usecase.** { *; }
-
-# Keep enums
--keep enum com.shreyash.dotrack.domain.** { *; }
-
-# Keep data classes with all their fields
--keepclassmembers class com.shreyash.dotrack.domain.model.** {
-    *;
-}
-
-# Keep classes annotated with Hilt
--keep @javax.inject.Inject class * { *; }
--keep @dagger.Module class * { *; }
+#
+# This module contains only plain models, repository interfaces, and use cases.
+# Everything is referenced directly by the app and data modules, so R8 can
+# freely shrink, inline, and obfuscate these classes.

--- a/domain/src/main/java/com/shreyash/dotrack/domain/model/TaskDeleteScope.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/model/TaskDeleteScope.kt
@@ -1,0 +1,7 @@
+package com.shreyash.dotrack.domain.model
+
+enum class TaskDeleteScope {
+    ALL,
+    COMPLETED,
+    INCOMPLETE
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/repository/TaskRepository.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/repository/TaskRepository.kt
@@ -16,7 +16,7 @@ interface TaskRepository {
         priority: Priority,
         reminderEnabled: Boolean,
         categoryId: String? = null
-    ): Result<Unit>
+    ): Result<String>
 
     suspend fun updateTask(task: Task): Result<Unit>
     suspend fun deleteTask(id: String): Result<Unit>

--- a/domain/src/main/java/com/shreyash/dotrack/domain/repository/TaskRepository.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/repository/TaskRepository.kt
@@ -20,7 +20,9 @@ interface TaskRepository {
 
     suspend fun updateTask(task: Task): Result<Unit>
     suspend fun deleteTask(id: String): Result<Unit>
-    suspend fun deleteAllTask(): Result<Unit>
+    suspend fun deleteAllTasks(): Result<Unit>
+    suspend fun deleteCompletedTasks(): Result<Unit>
+    suspend fun deleteIncompleteTasks(): Result<Unit>
     suspend fun completeTask(id: String): Result<Unit>
     suspend fun uncompleteTask(id: String): Result<Unit>
     suspend fun disableReminder(id: String): Result<Unit>

--- a/domain/src/main/java/com/shreyash/dotrack/domain/repository/UserPreferencesRepository.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/repository/UserPreferencesRepository.kt
@@ -1,6 +1,8 @@
 package com.shreyash.dotrack.domain.repository
 
 import com.shreyash.dotrack.core.util.Result
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -78,4 +80,24 @@ interface UserPreferencesRepository {
      * @param mode "system", "light", or "dark"
      */
     suspend fun setDarkMode(mode: String): Result<Unit>
+
+    /**
+     * Get the task list sort option as a Flow
+     */
+    fun getSortOption(): Flow<SortOption>
+
+    /**
+     * Set the task list sort option
+     */
+    suspend fun setSortOption(option: SortOption): Result<Unit>
+
+    /**
+     * Get the task list sort direction as a Flow
+     */
+    fun getSortDirection(): Flow<SortDirection>
+
+    /**
+     * Set the task list sort direction
+     */
+    suspend fun setSortDirection(direction: SortDirection): Result<Unit>
 }

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/GetSortDirectionUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/GetSortDirectionUseCase.kt
@@ -1,0 +1,20 @@
+package com.shreyash.dotrack.domain.usecase.preferences
+
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * Use case to get the task list sort direction
+ */
+class GetSortDirectionUseCase @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+    /**
+     * Get the task list sort direction as a Flow
+     */
+    operator fun invoke(): Flow<SortDirection> {
+        return userPreferencesRepository.getSortDirection()
+    }
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/GetSortOptionUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/GetSortOptionUseCase.kt
@@ -1,0 +1,20 @@
+package com.shreyash.dotrack.domain.usecase.preferences
+
+import com.shreyash.dotrack.domain.model.SortOption
+import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * Use case to get the task list sort option
+ */
+class GetSortOptionUseCase @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+    /**
+     * Get the task list sort option as a Flow
+     */
+    operator fun invoke(): Flow<SortOption> {
+        return userPreferencesRepository.getSortOption()
+    }
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/SetSortDirectionUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/SetSortDirectionUseCase.kt
@@ -1,0 +1,20 @@
+package com.shreyash.dotrack.domain.usecase.preferences
+
+import com.shreyash.dotrack.core.util.Result
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
+import javax.inject.Inject
+
+/**
+ * Use case to set the task list sort direction
+ */
+class SetSortDirectionUseCase @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+    /**
+     * Set the task list sort direction
+     */
+    suspend operator fun invoke(direction: SortDirection): Result<Unit> {
+        return userPreferencesRepository.setSortDirection(direction)
+    }
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/SetSortOptionUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/SetSortOptionUseCase.kt
@@ -1,0 +1,20 @@
+package com.shreyash.dotrack.domain.usecase.preferences
+
+import com.shreyash.dotrack.core.util.Result
+import com.shreyash.dotrack.domain.model.SortOption
+import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
+import javax.inject.Inject
+
+/**
+ * Use case to set the task list sort option
+ */
+class SetSortOptionUseCase @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+    /**
+     * Set the task list sort option
+     */
+    suspend operator fun invoke(option: SortOption): Result<Unit> {
+        return userPreferencesRepository.setSortOption(option)
+    }
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/task/AddTaskUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/task/AddTaskUseCase.kt
@@ -16,7 +16,7 @@ class AddTaskUseCase @Inject constructor(
         priority: Priority,
         reminderEnabled: Boolean,
         categoryId: String? = null
-    ): Result<Unit> {
+    ): Result<String> {
         if (title.isBlank()) {
             return Result.Error(Exception("Title cannot be empty"))
         }

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/task/DeleteTaskUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/task/DeleteTaskUseCase.kt
@@ -10,8 +10,4 @@ class DeleteTaskUseCase @Inject constructor(
     suspend operator fun invoke(id: String): Result<Unit> {
         return taskRepository.deleteTask(id)
     }
-
-    suspend operator fun invoke(): Result<Unit> {
-        return taskRepository.deleteAllTask()
-    }
 }

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/task/DeleteTasksUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/task/DeleteTasksUseCase.kt
@@ -1,0 +1,18 @@
+package com.shreyash.dotrack.domain.usecase.task
+
+import com.shreyash.dotrack.core.util.Result
+import com.shreyash.dotrack.domain.model.TaskDeleteScope
+import com.shreyash.dotrack.domain.repository.TaskRepository
+import javax.inject.Inject
+
+class DeleteTasksUseCase @Inject constructor(
+    private val taskRepository: TaskRepository
+) {
+    suspend operator fun invoke(scope: TaskDeleteScope): Result<Unit> {
+        return when (scope) {
+            TaskDeleteScope.ALL -> taskRepository.deleteAllTasks()
+            TaskDeleteScope.COMPLETED -> taskRepository.deleteCompletedTasks()
+            TaskDeleteScope.INCOMPLETE -> taskRepository.deleteIncompleteTasks()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes 2 issues found while investigating the Play Console R8 warning and missing notifications, plus 2 UX improvements.

### 1. R8 optimization (Play Console warning)
The app's shrink rate was ~11% because of blanket `-keep` rules that kept entire packages. The real culprit was the library modules' `consumer-rules.pro` files (shipped inside AARs and merged into the app's R8 run), not just `app/proguard-rules.pro`.

**Changes:**
- `app/proguard-rules.pro` — trimmed to only what reflection/codegen needs
- `data/consumer-rules.pro` — was keeping all data packages + Retrofit/Moshi (unused); now only Room `@Entity` + `RoomDatabase` subclasses
- `domain/consumer-rules.pro` — was keeping all models/usecases/repos; now empty (all direct references)
- `core/consumer-rules.pro` — was keeping `core.**` + Compose; now empty

**Results:** classes 18,704 → 3,636 (−80.6%), methods 133,886 → 18,097 (−86.5%), APK 4.1 MB → 1.9 MB. Zero R8 warnings.

### 2. Reminder notifications never scheduled for new tasks (pre-existing bug)
`addTask` returned `Result<Unit>`, so the new task's ID never reached the ViewModel — `savedTaskId` stayed `null` and `scheduleReminder()` was skipped. The reminder flag was saved to the DB (showing "Reminder enabled") but no WorkManager work was ever enqueued, so no notification ever fired.

**Changes:**
- `TaskRepository.addTask` / `AddTaskUseCase` — return `Result<String>` (created task ID)
- `TaskRepositoryImpl` — return the created task's ID
- `AddEditTaskViewModel.saveTask` — capture the new task ID and pass it to the reminder scheduler

### 3. Sort preference not persisted (UX fix)
Sort option/direction reset to Due Date on every app restart.

**Changes:**
- `UserPreferencesRepository` + impl — persist `sort_option` / `sort_direction` in DataStore
- 4 new use cases (`Get`/`SetSortOption`, `Get`/`SetSortDirection`)
- `TasksViewModel` — restores persisted sort on init (guard prevents initial DataStore emission from overriding a user's selection) and writes through on every change/toggle/reset

### 4. Scope-based delete dialog (UX improvement)
The toolbar delete button opened a single "Clear Completed" confirmation. It's now a selection dialog with live task counts.

**Changes:**
- `TaskDao` — explicit `deleteAllTasks`, `deleteCompletedTasks` (renamed from misleading `deleteAllTask`), `deleteIncompleteTasks`
- `TaskRepository` + impl — 3 explicit delete methods
- New `TaskDeleteScope` enum (ALL / COMPLETED / INCOMPLETE) + `DeleteTasksUseCase`
- `TasksViewModel.deleteTasks(scope)` — cancels pending WorkManager reminders for affected tasks (fixes stale notifications after toolbar delete), keeps the 2s progress overlay, refreshes wallpaper + widgets
- `TasksScreen` — redesigned dialog: X close icon, selectable option cards ("Completed" / "Incomplete") with live counts, disabled state when a scope is empty, ✓ badge on selection, and a red destructive action button that adapts its label ("Delete Completed" / "Delete Incomplete" / "Delete All Tasks") and stays disabled until a scope is selected
- `TasksViewModel` — exposes `taskCounts` StateFlow for the dialog

### Verification
- Unit tests pass
- Release APK installed on device: Hilt DI, Room read/write, navigation, task creation all work — no crashes, no ClassNotFound/NoSuchMethod
- Reminder flow verified end-to-end: WorkManager job enqueued, `ReminderWorker` executed, notification posted
- R8 obfuscation confirmed working (single-letter class names visible in logs)
- Delete dialog verified on device with live counts (12 tasks → Completed 4 / Incomplete 8)