### PR TITLE
Add Hindi, Japanese, German language support + in-app language picker

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     implementation(libs.compose.ui.graphics)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons.extended)
     implementation(libs.compose.activity)
     implementation(libs.compose.navigation)
     implementation(libs.compose.hilt.navigation)

--- a/app/src/main/java/com/shreyash/dotrack/DoTrackApplication.kt
+++ b/app/src/main/java/com/shreyash/dotrack/DoTrackApplication.kt
@@ -3,7 +3,10 @@ package com.shreyash.dotrack
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 /**
@@ -16,6 +19,16 @@ class DoTrackApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
+    @Inject
+    lateinit var userPreferencesRepository: UserPreferencesRepository
+
+    /**
+     * Synchronous read of the persisted app language, used by MainActivity's
+     * attachBaseContext to wrap the configuration before the first frame.
+     */
+    fun getLanguageCodeSync(): String = runBlocking {
+        userPreferencesRepository.getLanguage().first()
+    }
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()

--- a/app/src/main/java/com/shreyash/dotrack/MainActivity.kt
+++ b/app/src/main/java/com/shreyash/dotrack/MainActivity.kt
@@ -1,6 +1,10 @@
 package com.shreyash.dotrack
 
+import android.app.Activity
+import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -20,27 +24,50 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.shreyash.dotrack.core.ui.theme.DoTrackTheme
+import com.shreyash.dotrack.domain.model.AppLanguage
 import com.shreyash.dotrack.navigation.DeepLinkHandler
 import com.shreyash.dotrack.navigation.DoTrackBottomNavigation
 import com.shreyash.dotrack.navigation.DoTrackNavHost
 import com.shreyash.dotrack.navigation.bottomNavDestinations
 import com.shreyash.dotrack.ui.ThemeViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.Locale
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     private var deepLinkCounter by mutableIntStateOf(0)
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(applyAppLocale(newBase))
+    }
+
+    /**
+     * On Android < 13 the per-app locale has to be applied manually by wrapping
+     * the base context. On 13+ the system LocaleManager handles it.
+     */
+    private fun applyAppLocale(base: Context): Context {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) return base
+        val application = application as? DoTrackApplication ?: return base
+        val languageCode = application.getLanguageCodeSync()
+        if (languageCode == AppLanguage.SYSTEM.value) return base
+        val locale = Locale.forLanguageTag(languageCode)
+        val config = Configuration(base.resources.configuration)
+        config.setLocale(locale)
+        return base.createConfigurationContext(config)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -81,6 +108,21 @@ fun DoTrackApp(
         "dark" -> true
         "light" -> false
         else -> isSystemInDarkTheme()
+    }
+
+    val languagePref by themeViewModel.language.collectAsState()
+    var isInitialLanguage by remember { mutableStateOf(true) }
+    val activity = LocalContext.current as? Activity
+    LaunchedEffect(languagePref) {
+        if (isInitialLanguage) {
+            isInitialLanguage = false
+            return@LaunchedEffect
+        }
+        // On Android < 13 the locale is applied manually, so the activity
+        // needs recreation for the new resources to take effect.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            activity?.recreate()
+        }
     }
 
     DoTrackTheme(darkTheme = isDark) {

--- a/app/src/main/java/com/shreyash/dotrack/ui/ThemeViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/ThemeViewModel.kt
@@ -5,7 +5,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.shreyash.dotrack.domain.model.AppLanguage
 import com.shreyash.dotrack.domain.usecase.preferences.GetDarkModeUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetLanguageUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetDarkModeUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
@@ -16,11 +18,15 @@ import javax.inject.Inject
 @HiltViewModel
 class ThemeViewModel @Inject constructor(
     private val getDarkModeUseCase: GetDarkModeUseCase,
-    private val setDarkModeUseCase: SetDarkModeUseCase
+    private val setDarkModeUseCase: SetDarkModeUseCase,
+    private val getLanguageUseCase: GetLanguageUseCase
 ) : ViewModel() {
 
     val darkMode = getDarkModeUseCase()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "system")
+
+    val language = getLanguageUseCase()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AppLanguage.SYSTEM.value)
 
     var isUpdating by mutableStateOf(false)
         private set

--- a/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsScreen.kt
@@ -24,11 +24,16 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -44,12 +49,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -64,6 +71,7 @@ import com.github.skydoves.colorpicker.compose.ColorEnvelope
 import com.github.skydoves.colorpicker.compose.HsvColorPicker
 import com.github.skydoves.colorpicker.compose.rememberColorPickerController
 import com.shreyash.dotrack.R
+import com.shreyash.dotrack.domain.model.AppLanguage
 import com.shreyash.dotrack.domain.model.Priority
 
 @Preview(showBackground = true)
@@ -88,6 +96,7 @@ private fun SettingsPreviewContent() {
             currentWallpaperColor = "#1A2980",
             secondaryWallpaperColor = "#26D0CE",
             currentDarkMode = "system",
+            currentLanguage = "system",
             isNotificationEnabled = false,
             highPriorityColor = "#FF4444",
             mediumPriorityColor = "#FFBB33",
@@ -97,6 +106,7 @@ private fun SettingsPreviewContent() {
             onSecondaryWallpaperColorClick = {},
             onPriorityColorClick = {},
             onDarkModeChange = {},
+            onLanguageChange = {},
             onSyncWallpaper = {},
             onNotificationPermissionClick = {}
         )
@@ -118,6 +128,7 @@ fun SettingsScreen(
     val currentWallpaperColor by vm.wallpaperColor.collectAsState()
     val secondaryWallpaperColor by vm.wallpaperSecondaryColor.collectAsState()
     val currentDarkMode by vm.darkMode.collectAsState()
+    val currentLanguage by vm.language.collectAsState()
     val highPriorityColor by vm.highPriorityColor.collectAsState()
     val mediumPriorityColor by vm.mediumPriorityColor.collectAsState()
     val lowPriorityColor by vm.lowPriorityColor.collectAsState()
@@ -185,6 +196,7 @@ fun SettingsScreen(
             currentWallpaperColor = currentWallpaperColor,
             secondaryWallpaperColor = secondaryWallpaperColor,
             currentDarkMode = currentDarkMode,
+            currentLanguage = currentLanguage,
             isNotificationEnabled = isNotificationEnabled,
             highPriorityColor = highPriorityColor,
             mediumPriorityColor = mediumPriorityColor,
@@ -194,6 +206,7 @@ fun SettingsScreen(
             onSecondaryWallpaperColorClick = { vm.showSecondaryWallpaperColorPicker() },
             onPriorityColorClick = { priority -> vm.showPriorityColorPicker(priority) },
             onDarkModeChange = { vm.setDarkMode(it) },
+            onLanguageChange = { vm.setLanguage(it) },
             onSyncWallpaper = { vm.updateWallpaper() },
             onNotificationPermissionClick = {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !isNotificationEnabled) {
@@ -211,6 +224,7 @@ private fun SettingsContent(
     currentWallpaperColor: String,
     secondaryWallpaperColor: String,
     currentDarkMode: String,
+    currentLanguage: String,
     isNotificationEnabled: Boolean,
     highPriorityColor: String,
     mediumPriorityColor: String,
@@ -220,6 +234,7 @@ private fun SettingsContent(
     onSecondaryWallpaperColorClick: () -> Unit,
     onPriorityColorClick: (Priority) -> Unit,
     onDarkModeChange: (String) -> Unit,
+    onLanguageChange: (String) -> Unit,
     onSyncWallpaper: () -> Unit,
     onNotificationPermissionClick: () -> Unit,
 ) {
@@ -295,22 +310,42 @@ private fun SettingsContent(
         SectionHeader(title = stringResource(R.string.appearance))
 
         SectionCard {
-            DarkModeOption(
-                label = stringResource(R.string.dark_mode_system),
-                selected = currentDarkMode == "system",
-                onClick = { onDarkModeChange("system") }
+            SettingDropdownItem(
+                label = stringResource(R.string.dark_mode),
+                value = when (currentDarkMode) {
+                    "dark" -> stringResource(R.string.dark_mode_dark)
+                    "light" -> stringResource(R.string.dark_mode_light)
+                    else -> stringResource(R.string.dark_mode_system)
+                },
+                options = listOf(
+                    stringResource(R.string.dark_mode_system) to "system",
+                    stringResource(R.string.dark_mode_light) to "light",
+                    stringResource(R.string.dark_mode_dark) to "dark"
+                ),
+                selectedValue = currentDarkMode,
+                leadingIcon = Icons.Default.DarkMode,
+                onOptionSelected = onDarkModeChange
             )
             SectionDivider()
-            DarkModeOption(
-                label = stringResource(R.string.dark_mode_light),
-                selected = currentDarkMode == "light",
-                onClick = { onDarkModeChange("light") }
-            )
-            SectionDivider()
-            DarkModeOption(
-                label = stringResource(R.string.dark_mode_dark),
-                selected = currentDarkMode == "dark",
-                onClick = { onDarkModeChange("dark") }
+            SettingDropdownItem(
+                label = stringResource(R.string.language),
+                value = when (currentLanguage) {
+                    AppLanguage.ENGLISH.value -> stringResource(R.string.language_english)
+                    AppLanguage.HINDI.value -> stringResource(R.string.language_hindi)
+                    AppLanguage.JAPANESE.value -> stringResource(R.string.language_japanese)
+                    AppLanguage.GERMAN.value -> stringResource(R.string.language_german)
+                    else -> stringResource(R.string.language_system)
+                },
+                options = listOf(
+                    stringResource(R.string.language_system) to AppLanguage.SYSTEM.value,
+                    stringResource(R.string.language_english) to AppLanguage.ENGLISH.value,
+                    stringResource(R.string.language_hindi) to AppLanguage.HINDI.value,
+                    stringResource(R.string.language_japanese) to AppLanguage.JAPANESE.value,
+                    stringResource(R.string.language_german) to AppLanguage.GERMAN.value
+                ),
+                selectedValue = currentLanguage,
+                leadingIcon = Icons.Default.Language,
+                onOptionSelected = onLanguageChange
             )
         }
 
@@ -500,28 +535,85 @@ fun WallpaperColorCircle(
 }
 
 @Composable
-fun DarkModeOption(
+fun SettingDropdownItem(
     label: String,
-    selected: Boolean,
-    onClick: () -> Unit
+    value: String,
+    options: List<Pair<String, String>>,
+    selectedValue: String,
+    leadingIcon: ImageVector? = null,
+    onOptionSelected: (String) -> Unit
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.weight(1f)
-        )
-        if (selected) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .clickable(onClick = { expanded = true })
+                .padding(vertical = 14.dp, horizontal = 8.dp)
+        ) {
+            if (leadingIcon != null) {
+                Icon(
+                    imageVector = leadingIcon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
             Icon(
-                imageVector = Icons.Default.Check,
+                imageVector = Icons.Default.ArrowDropDown,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            options.forEach { (optionLabel, optionValue) ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = optionLabel,
+                            fontWeight = if (optionValue == selectedValue) {
+                                FontWeight.SemiBold
+                            } else {
+                                FontWeight.Normal
+                            }
+                        )
+                    },
+                    leadingIcon = {
+                        if (optionValue == selectedValue) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    },
+                    onClick = {
+                        onOptionSelected(optionValue)
+                        expanded = false
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsViewModel.kt
@@ -1,9 +1,11 @@
 package com.shreyash.dotrack.ui.settings
 
 import android.Manifest
+import android.app.LocaleManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.LocaleList
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -17,11 +19,13 @@ import com.shreyash.dotrack.core.ui.theme.DEFAULT_LOW_PRIORITY_COLOR
 import com.shreyash.dotrack.core.ui.theme.DEFAULT_MEDIUM_PRIORITY_COLOR
 import com.shreyash.dotrack.core.ui.theme.DEFAULT_TOP_COLOR
 import com.shreyash.dotrack.core.util.WallpaperGenerator
+import com.shreyash.dotrack.domain.model.AppLanguage
 import com.shreyash.dotrack.domain.model.DarkMode
 import com.shreyash.dotrack.domain.model.Priority
 import com.shreyash.dotrack.domain.usecase.preferences.GetAutoWallpaperEnabledUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetDarkModeUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetHighPriorityColorUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetLanguageUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetLowPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetMediumPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetSecondaryWallpaperColorUseCase
@@ -29,6 +33,7 @@ import com.shreyash.dotrack.domain.usecase.preferences.GetWallpaperColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetAutoWallpaperEnabledUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetDarkModeUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetHighPriorityColorUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.SetLanguageUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetLowPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetMediumPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetSecondaryWallpaperColorUseCase
@@ -63,6 +68,8 @@ class SettingsViewModel @Inject constructor(
     private val getTasksUseCase: GetTasksUseCase,
     private val getDarkModeUseCase: GetDarkModeUseCase,
     private val setDarkModeUseCase: SetDarkModeUseCase,
+    private val getLanguageUseCase: GetLanguageUseCase,
+    private val setLanguageUseCase: SetLanguageUseCase,
 ) : ViewModel() {
 
 
@@ -147,6 +154,40 @@ class SettingsViewModel @Inject constructor(
     fun setDarkMode(mode: String) {
         viewModelScope.launch {
             setDarkModeUseCase(mode)
+        }
+    }
+
+    /**
+     * App language state
+     */
+    val language: StateFlow<String> = getLanguageUseCase()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = AppLanguage.SYSTEM.value
+        )
+
+    /**
+     * Set app language and apply it app-wide
+     * On Android 13+ the system applies the locale and recreates the activity;
+     * on older versions MainActivity handles recreation via the language flow.
+     */
+    fun setLanguage(language: String) {
+        viewModelScope.launch {
+            setLanguageUseCase(language)
+            applyLanguageToApp(language)
+        }
+    }
+
+    private fun applyLanguageToApp(language: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val localeManager = context.getSystemService(LocaleManager::class.java)
+            val locales = if (language == AppLanguage.SYSTEM.value) {
+                LocaleList.forLanguageTags("")
+            } else {
+                LocaleList.forLanguageTags(language)
+            }
+            localeManager.applicationLocales = locales
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,155 @@
+<resources>
+    <string name="app_name">DoTrack</string>
+
+    <!-- General -->
+    <string name="cancel">Abbrechen</string>
+    <string name="ok">OK</string>
+    <string name="next">Weiter</string>
+    <string name="apply">Übernehmen</string>
+    <string name="delete">Löschen</string>
+    <string name="back">Zurück</string>
+    <string name="close">Schließen</string>
+    <string name="save">Speichern</string>
+
+    <!-- Time Picker -->
+    <string name="select_time">Uhrzeit wählen</string>
+
+    <!-- Tasks Screen -->
+    <string name="add_task">Aufgabe hinzufügen</string>
+    <string name="edit_task">Aufgabe bearbeiten</string>
+    <string name="save_task">Aufgabe speichern</string>
+    <string name="delete_task">Aufgabe löschen</string>
+    <string name="delete_tasks_title">Aufgaben löschen</string>
+    <string name="delete_tasks_summary">%1$d Aufgaben · Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="delete_all_tasks">Alle Aufgaben löschen</string>
+    <string name="delete_completed_tasks">Erledigt</string>
+    <string name="delete_incomplete_tasks">Offen</string>
+    <string name="delete_completed_action">Erledigte löschen</string>
+    <string name="delete_incomplete_action">Offene löschen</string>
+    <string name="delete_task_confirm">Möchten Sie diese Aufgabe wirklich löschen?</string>
+    <string name="tasks_deleted">Aufgaben gelöscht</string>
+    <string name="no_tasks_yet">Noch keine Aufgaben. Fügen Sie eine hinzu!</string>
+    <string name="set_wallpaper">Wallpaper festlegen</string>
+    <string name="set_wallpaper_confirm">Möchten Sie wirklich ein Wallpaper festlegen? Diese Aktion kann nicht rückgängig gemacht werden.</string>
+    <string name="wallpaper_in_progress">Neues Wallpaper wird erstellt…</string>
+    <string name="applying_wallpaper">Wallpaper wird angewendet…</string>
+    <string name="deleting_task">Aufgabe wird gelöscht…</string>
+    <string name="set_as_wallpaper">Als Wallpaper festlegen</string>
+    <string name="delete_all_tasks_content_desc">Aufgaben löschen</string>
+    <string name="error_format">Fehler: %s</string>
+    <string name="due_label">Fällig: %s</string>
+    <string name="delete_task_content_desc">Aufgabe löschen</string>
+
+    <!-- Task Detail -->
+    <string name="task_details">Aufgabendetails</string>
+    <string name="description">Beschreibung</string>
+    <string name="no_description">Keine Beschreibung</string>
+    <string name="priority">Priorität</string>
+    <string name="due_date">Fälligkeitsdatum</string>
+    <string name="created">Erstellt</string>
+    <string name="last_updated">Zuletzt aktualisiert</string>
+
+    <!-- Add/Edit Task -->
+    <string name="title_label">Titel</string>
+    <string name="description_label">Beschreibung</string>
+    <string name="no_due_date">Kein Fälligkeitsdatum</string>
+    <string name="due_date_optional">Fälligkeitsdatum (optional)</string>
+    <string name="select_date">Datum wählen</string>
+    <string name="saving_task">Aufgabe wird gespeichert…</string>
+    <string name="error_saving_task">Fehler beim Speichern der Aufgabe</string>
+    <string name="clear_due_date">Fälligkeitsdatum löschen</string>
+    <string name="enable_reminder">Erinnerung aktivieren (30 Min. vorher)</string>
+    <string name="reminder_helper">Sie erhalten eine Benachrichtigung 30 Minuten vor dem Fälligkeitszeitpunkt</string>
+    <string name="title_cannot_be_empty">Der Titel darf nicht leer sein</string>
+    <string name="sample_task">Beispielaufgabe</string>
+    <string name="sample_task_description">Dies ist eine Beispielbeschreibung für die Vorschau</string>
+
+    <!-- Categories -->
+    <string name="categories">Kategorien</string>
+    <string name="add_category">Kategorie hinzufügen</string>
+    <string name="edit_category">Kategorie bearbeiten</string>
+    <string name="save_category">Kategorie speichern</string>
+    <string name="category_name">Kategoriename</string>
+    <string name="no_categories_yet">Noch keine Kategorien. Fügen Sie eine hinzu!</string>
+    <string name="error_saving_category">Fehler beim Speichern der Kategorie</string>
+
+    <!-- Settings -->
+    <string name="settings">Einstellungen</string>
+    <string name="auto_wallpaper_updates">Automatische Wallpaper-Updates</string>
+    <string name="auto_wallpaper_subtitle">Wallpaper automatisch aktualisieren, wenn sich Aufgaben ändern</string>
+    <string name="wallpaper_color">Wallpaper-Farbe</string>
+    <string name="wallpaper_color_subtitle">Hintergrundfarbe für das Wallpaper wählen</string>
+    <string name="choose_wallpaper_color">Wallpaper-Farbe wählen</string>
+    <string name="choose_secondary_wallpaper_color">Sekundäre Wallpaper-Farbe wählen</string>
+    <string name="choose_high_priority_color">Farbe für hohe Priorität wählen</string>
+    <string name="choose_medium_priority_color">Farbe für mittlere Priorität wählen</string>
+    <string name="choose_low_priority_color">Farbe für niedrige Priorität wählen</string>
+    <string name="task_priority_colors">Farben der Aufgabenprioritäten</string>
+    <string name="high_priority">Hohe Priorität</string>
+    <string name="high_priority_subtitle">Farbe für Aufgaben mit hoher Priorität</string>
+    <string name="medium_priority">Mittlere Priorität</string>
+    <string name="medium_priority_subtitle">Farbe für Aufgaben mit mittlerer Priorität</string>
+    <string name="low_priority">Niedrige Priorität</string>
+    <string name="low_priority_subtitle">Farbe für Aufgaben mit niedriger Priorität</string>
+    <string name="notifications">Benachrichtigungen</string>
+    <string name="permission">Berechtigung</string>
+    <string name="enable_notification_permission">Benachrichtigungsberechtigung aktivieren</string>
+    <string name="notification_permission_title">Benachrichtigungsberechtigung</string>
+    <string name="notification_permission_message">DoTrack benötigt die Benachrichtigungsberechtigung, um Ihnen Erinnerungen für Ihre Aufgaben zu senden. Möchten Sie diese Berechtigung erteilen?</string>
+    <string name="grant_permission">Berechtigung erteilen</string>
+    <string name="not_now">Später</string>
+    <string name="sync_up">Synchronisieren</string>
+    <string name="sync_up_content_desc">Synchronisieren</string>
+    <string name="choose_color">Farbe wählen</string>
+
+    <!-- Bottom Nav -->
+    <string name="nav_tasks">Aufgaben</string>
+    <string name="nav_categories">Kategorien</string>
+    <string name="nav_settings">Einstellungen</string>
+
+    <!-- Reminder Worker -->
+    <string name="reminder_channel_id">reminder_channel</string>
+    <string name="reminder_channel_name">Aufgaben-Erinnerungen</string>
+    <string name="reminder_channel_desc">Benachrichtigungen für Aufgaben-Erinnerungen</string>
+    <string name="task_reminder">Aufgaben-Erinnerung</string>
+
+    <!-- Date formats -->
+    <string name="date_time_format">MMM dd, yyyy HH:mm</string>
+    <string name="date_format_widget">MMM dd, yyyy</string>
+
+    <!-- Time validation -->
+    <string name="time_cannot_be_in_past">Die ausgewählte Uhrzeit ist bereits vorbei. Bitte wählen Sie eine zukünftige Uhrzeit.</string>
+
+    <!-- Appearance -->
+    <string name="appearance">Darstellung</string>
+    <string name="dark_mode">Dunkelmodus</string>
+    <string name="dark_mode_system">Systemstandard</string>
+    <string name="dark_mode_light">Hell</string>
+    <string name="dark_mode_dark">Dunkel</string>
+
+    <!-- Sort -->
+    <string name="sort_by">Sortieren nach</string>
+    <string name="sort_due_date">Fälligkeitsdatum</string>
+    <string name="sort_priority">Priorität</string>
+    <string name="sort_created_date">Erstellungsdatum</string>
+    <string name="sort_title">Titel</string>
+    <string name="sort_ascending">Aufsteigend</string>
+    <string name="sort_descending">Absteigend</string>
+
+    <!-- Settings -->
+    <string name="primary">Primär</string>
+    <string name="secondary">Sekundär</string>
+
+    <!-- Filter -->
+    <string name="filter_by">Filtern nach</string>
+    <string name="filter_all">Alle</string>
+    <string name="filter_active">Aktiv</string>
+    <string name="filter_completed">Erledigt</string>
+    <string name="filter_status">Status</string>
+    <string name="reset">Zurücksetzen</string>
+
+    <!-- Widget -->
+    <string name="priority_high">H</string>
+    <string name="priority_medium">M</string>
+    <string name="priority_low">L</string>
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -127,6 +127,14 @@
     <string name="dark_mode_light">Hell</string>
     <string name="dark_mode_dark">Dunkel</string>
 
+    <!-- Language -->
+    <string name="language">Sprache</string>
+    <string name="language_system">Systemstandard</string>
+    <string name="language_english">English</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+
     <!-- Sort -->
     <string name="sort_by">Sortieren nach</string>
     <string name="sort_due_date">Fälligkeitsdatum</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,0 +1,155 @@
+<resources>
+    <string name="app_name">DoTrack</string>
+
+    <!-- General -->
+    <string name="cancel">रद्द करें</string>
+    <string name="ok">ठीक है</string>
+    <string name="next">अगला</string>
+    <string name="apply">लागू करें</string>
+    <string name="delete">हटाएँ</string>
+    <string name="back">वापस</string>
+    <string name="close">बंद करें</string>
+    <string name="save">सहेजें</string>
+
+    <!-- Time Picker -->
+    <string name="select_time">समय चुनें</string>
+
+    <!-- Tasks Screen -->
+    <string name="add_task">कार्य जोड़ें</string>
+    <string name="edit_task">कार्य संपादित करें</string>
+    <string name="save_task">कार्य सहेजें</string>
+    <string name="delete_task">कार्य हटाएँ</string>
+    <string name="delete_tasks_title">कार्य हटाएँ</string>
+    <string name="delete_tasks_summary">%1$d कार्य · यह क्रिया पूर्ववत नहीं की जा सकती।</string>
+    <string name="delete_all_tasks">सभी कार्य हटाएँ</string>
+    <string name="delete_completed_tasks">पूर्ण</string>
+    <string name="delete_incomplete_tasks">अधूरे</string>
+    <string name="delete_completed_action">पूर्ण कार्य हटाएँ</string>
+    <string name="delete_incomplete_action">अधूरे कार्य हटाएँ</string>
+    <string name="delete_task_confirm">क्या आप वाकई इस कार्य को हटाना चाहते हैं?</string>
+    <string name="tasks_deleted">कार्य हटा दिए गए</string>
+    <string name="no_tasks_yet">अभी कोई कार्य नहीं। एक जोड़ें!</string>
+    <string name="set_wallpaper">वॉलपेपर सेट करें</string>
+    <string name="set_wallpaper_confirm">क्या आप वाकई वॉलपेपर सेट करना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।</string>
+    <string name="wallpaper_in_progress">नया वॉलपेपर बन रहा है…</string>
+    <string name="applying_wallpaper">वॉलपेपर लागू हो रहा है…</string>
+    <string name="deleting_task">कार्य हटाया जा रहा है…</string>
+    <string name="set_as_wallpaper">वॉलपेपर के रूप में सेट करें</string>
+    <string name="delete_all_tasks_content_desc">कार्य हटाएँ</string>
+    <string name="error_format">त्रुटि: %s</string>
+    <string name="due_label">नियत तिथि: %s</string>
+    <string name="delete_task_content_desc">कार्य हटाएँ</string>
+
+    <!-- Task Detail -->
+    <string name="task_details">कार्य विवरण</string>
+    <string name="description">विवरण</string>
+    <string name="no_description">कोई विवरण नहीं</string>
+    <string name="priority">प्राथमिकता</string>
+    <string name="due_date">नियत तिथि</string>
+    <string name="created">बनाया गया</string>
+    <string name="last_updated">अंतिम अपडेट</string>
+
+    <!-- Add/Edit Task -->
+    <string name="title_label">शीर्षक</string>
+    <string name="description_label">विवरण</string>
+    <string name="no_due_date">कोई नियत तिथि नहीं</string>
+    <string name="due_date_optional">नियत तिथि (वैकल्पिक)</string>
+    <string name="select_date">तिथि चुनें</string>
+    <string name="saving_task">कार्य सहेजा जा रहा है…</string>
+    <string name="error_saving_task">कार्य सहेजने में त्रुटि</string>
+    <string name="clear_due_date">नियत तिथि हटाएँ</string>
+    <string name="enable_reminder">अनुस्मारक सक्षम करें (30 मिनट पहले)</string>
+    <string name="reminder_helper">आपको नियत समय से 30 मिनट पहले सूचना मिलेगी</string>
+    <string name="title_cannot_be_empty">शीर्षक खाली नहीं हो सकता</string>
+    <string name="sample_task">नमूना कार्य</string>
+    <string name="sample_task_description">यह पूर्वावलोकन के लिए नमूना कार्य विवरण है</string>
+
+    <!-- Categories -->
+    <string name="categories">श्रेणियाँ</string>
+    <string name="add_category">श्रेणी जोड़ें</string>
+    <string name="edit_category">श्रेणी संपादित करें</string>
+    <string name="save_category">श्रेणी सहेजें</string>
+    <string name="category_name">श्रेणी का नाम</string>
+    <string name="no_categories_yet">अभी कोई श्रेणी नहीं। एक जोड़ें!</string>
+    <string name="error_saving_category">श्रेणी सहेजने में त्रुटि</string>
+
+    <!-- Settings -->
+    <string name="settings">सेटिंग्स</string>
+    <string name="auto_wallpaper_updates">स्वचालित वॉलपेपर अपडेट</string>
+    <string name="auto_wallpaper_subtitle">कार्य बदलने पर वॉलपेपर स्वचालित रूप से अपडेट करें</string>
+    <string name="wallpaper_color">वॉलपेपर रंग</string>
+    <string name="wallpaper_color_subtitle">वॉलपेपर के लिए पृष्ठभूमि रंग चुनें</string>
+    <string name="choose_wallpaper_color">वॉलपेपर रंग चुनें</string>
+    <string name="choose_secondary_wallpaper_color">द्वितीयक वॉलपेपर रंग चुनें</string>
+    <string name="choose_high_priority_color">उच्च प्राथमिकता रंग चुनें</string>
+    <string name="choose_medium_priority_color">मध्यम प्राथमिकता रंग चुनें</string>
+    <string name="choose_low_priority_color">कम प्राथमिकता रंग चुनें</string>
+    <string name="task_priority_colors">कार्य प्राथमिकता रंग</string>
+    <string name="high_priority">उच्च प्राथमिकता</string>
+    <string name="high_priority_subtitle">उच्च प्राथमिकता वाले कार्यों के लिए रंग</string>
+    <string name="medium_priority">मध्यम प्राथमिकता</string>
+    <string name="medium_priority_subtitle">मध्यम प्राथमिकता वाले कार्यों के लिए रंग</string>
+    <string name="low_priority">कम प्राथमिकता</string>
+    <string name="low_priority_subtitle">कम प्राथमिकता वाले कार्यों के लिए रंग</string>
+    <string name="notifications">सूचनाएँ</string>
+    <string name="permission">अनुमति</string>
+    <string name="enable_notification_permission">सूचना अनुमतियाँ सक्षम करें</string>
+    <string name="notification_permission_title">सूचना अनुमति</string>
+    <string name="notification_permission_message">DoTrack को आपके कार्यों के लिए अनुस्मारक भेजने हेतु सूचना अनुमति की आवश्यकता है। क्या आप यह अनुमति देना चाहते हैं?</string>
+    <string name="grant_permission">अनुमति दें</string>
+    <string name="not_now">अभी नहीं</string>
+    <string name="sync_up">सिंक-अप</string>
+    <string name="sync_up_content_desc">सिंक करें</string>
+    <string name="choose_color">रंग चुनें</string>
+
+    <!-- Bottom Nav -->
+    <string name="nav_tasks">कार्य</string>
+    <string name="nav_categories">श्रेणियाँ</string>
+    <string name="nav_settings">सेटिंग्स</string>
+
+    <!-- Reminder Worker -->
+    <string name="reminder_channel_id">reminder_channel</string>
+    <string name="reminder_channel_name">कार्य अनुस्मारक</string>
+    <string name="reminder_channel_desc">कार्य अनुस्मारकों के लिए सूचनाएँ</string>
+    <string name="task_reminder">कार्य अनुस्मारक</string>
+
+    <!-- Date formats -->
+    <string name="date_time_format">MMM dd, yyyy HH:mm</string>
+    <string name="date_format_widget">MMM dd, yyyy</string>
+
+    <!-- Time validation -->
+    <string name="time_cannot_be_in_past">चुना गया समय बीत चुका है। कृपया भविष्य का समय चुनें।</string>
+
+    <!-- Appearance -->
+    <string name="appearance">दिखावट</string>
+    <string name="dark_mode">डार्क मोड</string>
+    <string name="dark_mode_system">सिस्टम डिफ़ॉल्ट</string>
+    <string name="dark_mode_light">लाइट</string>
+    <string name="dark_mode_dark">डार्क</string>
+
+    <!-- Sort -->
+    <string name="sort_by">क्रमबद्ध करें</string>
+    <string name="sort_due_date">नियत तिथि</string>
+    <string name="sort_priority">प्राथमिकता</string>
+    <string name="sort_created_date">निर्माण तिथि</string>
+    <string name="sort_title">शीर्षक</string>
+    <string name="sort_ascending">आरोही</string>
+    <string name="sort_descending">अवरोही</string>
+
+    <!-- Settings -->
+    <string name="primary">प्राथमिक</string>
+    <string name="secondary">द्वितीयक</string>
+
+    <!-- Filter -->
+    <string name="filter_by">फ़िल्टर करें</string>
+    <string name="filter_all">सभी</string>
+    <string name="filter_active">सक्रिय</string>
+    <string name="filter_completed">पूर्ण</string>
+    <string name="filter_status">स्थिति</string>
+    <string name="reset">रीसेट</string>
+
+    <!-- Widget -->
+    <string name="priority_high">H</string>
+    <string name="priority_medium">M</string>
+    <string name="priority_low">L</string>
+</resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -127,6 +127,14 @@
     <string name="dark_mode_light">लाइट</string>
     <string name="dark_mode_dark">डार्क</string>
 
+    <!-- Language -->
+    <string name="language">भाषा</string>
+    <string name="language_system">सिस्टम डिफ़ॉल्ट</string>
+    <string name="language_english">English</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+
     <!-- Sort -->
     <string name="sort_by">क्रमबद्ध करें</string>
     <string name="sort_due_date">नियत तिथि</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,155 @@
+<resources>
+    <string name="app_name">DoTrack</string>
+
+    <!-- General -->
+    <string name="cancel">キャンセル</string>
+    <string name="ok">OK</string>
+    <string name="next">次へ</string>
+    <string name="apply">適用</string>
+    <string name="delete">削除</string>
+    <string name="back">戻る</string>
+    <string name="close">閉じる</string>
+    <string name="save">保存</string>
+
+    <!-- Time Picker -->
+    <string name="select_time">時刻を選択</string>
+
+    <!-- Tasks Screen -->
+    <string name="add_task">タスクを追加</string>
+    <string name="edit_task">タスクを編集</string>
+    <string name="save_task">タスクを保存</string>
+    <string name="delete_task">タスクを削除</string>
+    <string name="delete_tasks_title">タスクを削除</string>
+    <string name="delete_tasks_summary">%1$d件のタスク · この操作は元に戻せません。</string>
+    <string name="delete_all_tasks">すべてのタスクを削除</string>
+    <string name="delete_completed_tasks">完了</string>
+    <string name="delete_incomplete_tasks">未完了</string>
+    <string name="delete_completed_action">完了タスクを削除</string>
+    <string name="delete_incomplete_action">未完了タスクを削除</string>
+    <string name="delete_task_confirm">このタスクを削除してもよろしいですか？</string>
+    <string name="tasks_deleted">タスクを削除しました</string>
+    <string name="no_tasks_yet">タスクはまだありません。追加してください！</string>
+    <string name="set_wallpaper">壁紙を設定</string>
+    <string name="set_wallpaper_confirm">壁紙を設定してもよろしいですか？この操作は元に戻せません。</string>
+    <string name="wallpaper_in_progress">新しい壁紙を作成中…</string>
+    <string name="applying_wallpaper">壁紙を適用中…</string>
+    <string name="deleting_task">タスクを削除中…</string>
+    <string name="set_as_wallpaper">壁紙として設定</string>
+    <string name="delete_all_tasks_content_desc">タスクを削除</string>
+    <string name="error_format">エラー: %s</string>
+    <string name="due_label">期限: %s</string>
+    <string name="delete_task_content_desc">タスクを削除</string>
+
+    <!-- Task Detail -->
+    <string name="task_details">タスクの詳細</string>
+    <string name="description">説明</string>
+    <string name="no_description">説明なし</string>
+    <string name="priority">優先度</string>
+    <string name="due_date">期限</string>
+    <string name="created">作成日</string>
+    <string name="last_updated">最終更新</string>
+
+    <!-- Add/Edit Task -->
+    <string name="title_label">タイトル</string>
+    <string name="description_label">説明</string>
+    <string name="no_due_date">期限なし</string>
+    <string name="due_date_optional">期限（任意）</string>
+    <string name="select_date">日付を選択</string>
+    <string name="saving_task">タスクを保存中…</string>
+    <string name="error_saving_task">タスクの保存エラー</string>
+    <string name="clear_due_date">期限をクリア</string>
+    <string name="enable_reminder">リマインダーを有効にする（30分前）</string>
+    <string name="reminder_helper">期限の30分前に通知を受け取ります</string>
+    <string name="title_cannot_be_empty">タイトルは空にできません</string>
+    <string name="sample_task">サンプルタスク</string>
+    <string name="sample_task_description">これはプレビュー用のサンプルタスクの説明です</string>
+
+    <!-- Categories -->
+    <string name="categories">カテゴリ</string>
+    <string name="add_category">カテゴリを追加</string>
+    <string name="edit_category">カテゴリを編集</string>
+    <string name="save_category">カテゴリを保存</string>
+    <string name="category_name">カテゴリ名</string>
+    <string name="no_categories_yet">カテゴリはまだありません。追加してください！</string>
+    <string name="error_saving_category">カテゴリの保存エラー</string>
+
+    <!-- Settings -->
+    <string name="settings">設定</string>
+    <string name="auto_wallpaper_updates">壁紙の自動更新</string>
+    <string name="auto_wallpaper_subtitle">タスクが変更されたときに壁紙を自動的に更新</string>
+    <string name="wallpaper_color">壁紙の色</string>
+    <string name="wallpaper_color_subtitle">壁紙の背景色を選択</string>
+    <string name="choose_wallpaper_color">壁紙の色を選択</string>
+    <string name="choose_secondary_wallpaper_color">セカンダリ壁紙の色を選択</string>
+    <string name="choose_high_priority_color">高優先度の色を選択</string>
+    <string name="choose_medium_priority_color">中優先度の色を選択</string>
+    <string name="choose_low_priority_color">低優先度の色を選択</string>
+    <string name="task_priority_colors">タスク優先度の色</string>
+    <string name="high_priority">高優先度</string>
+    <string name="high_priority_subtitle">高優先度タスクの色</string>
+    <string name="medium_priority">中優先度</string>
+    <string name="medium_priority_subtitle">中優先度タスクの色</string>
+    <string name="low_priority">低優先度</string>
+    <string name="low_priority_subtitle">低優先度タスクの色</string>
+    <string name="notifications">通知</string>
+    <string name="permission">権限</string>
+    <string name="enable_notification_permission">通知権限を有効にする</string>
+    <string name="notification_permission_title">通知権限</string>
+    <string name="notification_permission_message">DoTrackはタスクのリマインダーを送信するために通知権限が必要です。この権限を許可しますか？</string>
+    <string name="grant_permission">権限を許可</string>
+    <string name="not_now">後で</string>
+    <string name="sync_up">同期</string>
+    <string name="sync_up_content_desc">同期</string>
+    <string name="choose_color">色を選択</string>
+
+    <!-- Bottom Nav -->
+    <string name="nav_tasks">タスク</string>
+    <string name="nav_categories">カテゴリ</string>
+    <string name="nav_settings">設定</string>
+
+    <!-- Reminder Worker -->
+    <string name="reminder_channel_id">reminder_channel</string>
+    <string name="reminder_channel_name">タスクリマインダー</string>
+    <string name="reminder_channel_desc">タスクリマインダー用の通知</string>
+    <string name="task_reminder">タスクリマインダー</string>
+
+    <!-- Date formats -->
+    <string name="date_time_format">MMM dd, yyyy HH:mm</string>
+    <string name="date_format_widget">MMM dd, yyyy</string>
+
+    <!-- Time validation -->
+    <string name="time_cannot_be_in_past">選択した時刻はすでに過ぎています。将来の時刻を選択してください。</string>
+
+    <!-- Appearance -->
+    <string name="appearance">外観</string>
+    <string name="dark_mode">ダークモード</string>
+    <string name="dark_mode_system">システムデフォルト</string>
+    <string name="dark_mode_light">ライト</string>
+    <string name="dark_mode_dark">ダーク</string>
+
+    <!-- Sort -->
+    <string name="sort_by">並び替え</string>
+    <string name="sort_due_date">期限</string>
+    <string name="sort_priority">優先度</string>
+    <string name="sort_created_date">作成日</string>
+    <string name="sort_title">タイトル</string>
+    <string name="sort_ascending">昇順</string>
+    <string name="sort_descending">降順</string>
+
+    <!-- Settings -->
+    <string name="primary">プライマリ</string>
+    <string name="secondary">セカンダリ</string>
+
+    <!-- Filter -->
+    <string name="filter_by">フィルター</string>
+    <string name="filter_all">すべて</string>
+    <string name="filter_active">未完了</string>
+    <string name="filter_completed">完了</string>
+    <string name="filter_status">ステータス</string>
+    <string name="reset">リセット</string>
+
+    <!-- Widget -->
+    <string name="priority_high">H</string>
+    <string name="priority_medium">M</string>
+    <string name="priority_low">L</string>
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -127,6 +127,14 @@
     <string name="dark_mode_light">ライト</string>
     <string name="dark_mode_dark">ダーク</string>
 
+    <!-- Language -->
+    <string name="language">言語</string>
+    <string name="language_system">システムデフォルト</string>
+    <string name="language_english">English</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+
     <!-- Sort -->
     <string name="sort_by">並び替え</string>
     <string name="sort_due_date">期限</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,14 @@
     <string name="dark_mode_light">Light</string>
     <string name="dark_mode_dark">Dark</string>
 
+    <!-- Language -->
+    <string name="language">Language</string>
+    <string name="language_system">System Default</string>
+    <string name="language_english">English</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+
     <!-- Sort -->
     <string name="sort_by">Sort By</string>
     <string name="sort_due_date">Due Date</string>

--- a/app/src/test/java/com/shreyash/dotrack/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/shreyash/dotrack/ui/settings/SettingsViewModelTest.kt
@@ -9,12 +9,14 @@ import com.shreyash.dotrack.core.ui.theme.DEFAULT_MEDIUM_PRIORITY_COLOR
 import com.shreyash.dotrack.core.ui.theme.DEFAULT_TOP_COLOR
 import com.shreyash.dotrack.core.util.Result
 import com.shreyash.dotrack.core.util.WallpaperGenerator
+import com.shreyash.dotrack.domain.model.AppLanguage
+import com.shreyash.dotrack.domain.model.DarkMode
 import com.shreyash.dotrack.domain.model.Priority
 import com.shreyash.dotrack.domain.model.Task
-import com.shreyash.dotrack.domain.model.DarkMode
 import com.shreyash.dotrack.domain.usecase.preferences.GetAutoWallpaperEnabledUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetDarkModeUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetHighPriorityColorUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetLanguageUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetLowPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetMediumPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetSecondaryWallpaperColorUseCase
@@ -22,6 +24,7 @@ import com.shreyash.dotrack.domain.usecase.preferences.GetWallpaperColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetAutoWallpaperEnabledUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetDarkModeUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetHighPriorityColorUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.SetLanguageUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetLowPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetMediumPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.SetSecondaryWallpaperColorUseCase
@@ -70,6 +73,8 @@ class SettingsViewModelTest {
     private lateinit var getTasksUseCase: GetTasksUseCase
     private lateinit var getDarkModeUseCase: GetDarkModeUseCase
     private lateinit var setDarkModeUseCase: SetDarkModeUseCase
+    private lateinit var getLanguageUseCase: GetLanguageUseCase
+    private lateinit var setLanguageUseCase: SetLanguageUseCase
 
     // Class under test
     private lateinit var viewModel: SettingsViewModel
@@ -96,10 +101,13 @@ class SettingsViewModelTest {
         getTasksUseCase = mockk()
         getDarkModeUseCase = mockk()
         setDarkModeUseCase = mockk(relaxed = true)
+        getLanguageUseCase = mockk()
+        setLanguageUseCase = mockk(relaxed = true)
 
         // Default mock behavior
         every { getAutoWallpaperEnabledUseCase() } returns flowOf(false)
         every { getDarkModeUseCase() } returns flowOf(DarkMode.SYSTEM.value)
+        every { getLanguageUseCase() } returns flowOf(AppLanguage.SYSTEM.value)
         every { getWallpaperColorUseCase() } returns flowOf(DEFAULT_TOP_COLOR)
         every { getSecondaryWallpaperColorUseCase() } returns flowOf(DEFAULT_TOP_COLOR)
         every { getHighPriorityColorUseCase() } returns flowOf(DEFAULT_HIGH_PRIORITY_COLOR)
@@ -124,7 +132,9 @@ class SettingsViewModelTest {
             wallpaperGenerator = wallpaperGenerator,
             getTasksUseCase = getTasksUseCase,
             getDarkModeUseCase = getDarkModeUseCase,
-            setDarkModeUseCase = setDarkModeUseCase
+            setDarkModeUseCase = setDarkModeUseCase,
+            getLanguageUseCase = getLanguageUseCase,
+            setLanguageUseCase = setLanguageUseCase
         )
     }
 
@@ -284,7 +294,9 @@ class SettingsViewModelTest {
             wallpaperGenerator = wallpaperGenerator,
             getTasksUseCase = getTasksUseCase,
             getDarkModeUseCase = getDarkModeUseCase,
-            setDarkModeUseCase = setDarkModeUseCase
+            setDarkModeUseCase = setDarkModeUseCase,
+            getLanguageUseCase = getLanguageUseCase,
+            setLanguageUseCase = setLanguageUseCase
         )
 
         // Then - show color picker should not crash
@@ -333,5 +345,26 @@ class SettingsViewModelTest {
         // Test for secondary wallpaper
         viewModel.showSecondaryWallpaperColorPicker()
         assertEquals(ColorPickerMode.SECONDARY_WALLPAPER, viewModel.currentColorPickerMode)
+    }
+
+    @Test
+    fun `test set app language`() = runTest {
+        // Given
+        coEvery { setLanguageUseCase(AppLanguage.HINDI.value) } returns Result.Success(Unit)
+
+        // When
+        viewModel.setLanguage(AppLanguage.HINDI.value)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        coVerify { setLanguageUseCase(AppLanguage.HINDI.value) }
+    }
+
+    @Test
+    fun `test app language defaults to system`() {
+        // Given - default mock returns system language
+
+        // Then
+        assertEquals(AppLanguage.SYSTEM.value, viewModel.language.value)
     }
 }

--- a/data/src/main/java/com/shreyash/dotrack/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/data/src/main/java/com/shreyash/dotrack/data/repository/UserPreferencesRepositoryImpl.kt
@@ -37,6 +37,7 @@ class UserPreferencesRepositoryImpl @Inject constructor(
         val MEDIUM_PRIORITY_COLOR = stringPreferencesKey("medium_priority_color")
         val LOW_PRIORITY_COLOR = stringPreferencesKey("low_priority_color")
         val DARK_MODE = stringPreferencesKey("dark_mode")
+        val LANGUAGE = stringPreferencesKey("language")
         val SORT_OPTION = stringPreferencesKey("sort_option")
         val SORT_DIRECTION = stringPreferencesKey("sort_direction")
     }
@@ -211,6 +212,31 @@ class UserPreferencesRepositoryImpl @Inject constructor(
         return try {
             dataStore.edit { preferences ->
                 preferences[PreferencesKeys.DARK_MODE] = mode
+            }
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+
+    override fun getLanguage(): Flow<String> {
+        return dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
+            }
+            .map { preferences ->
+                preferences[PreferencesKeys.LANGUAGE] ?: "system"
+            }
+    }
+
+    override suspend fun setLanguage(language: String): Result<Unit> {
+        return try {
+            dataStore.edit { preferences ->
+                preferences[PreferencesKeys.LANGUAGE] = language
             }
             Result.Success(Unit)
         } catch (e: Exception) {

--- a/domain/src/main/java/com/shreyash/dotrack/domain/model/AppLanguage.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/model/AppLanguage.kt
@@ -1,0 +1,15 @@
+package com.shreyash.dotrack.domain.model
+
+enum class AppLanguage(val value: String) {
+    SYSTEM("system"),
+    ENGLISH("en"),
+    HINDI("hi"),
+    JAPANESE("ja"),
+    GERMAN("de");
+
+    companion object {
+        fun fromValue(value: String): AppLanguage {
+            return entries.firstOrNull { it.value == value } ?: SYSTEM
+        }
+    }
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/repository/UserPreferencesRepository.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/repository/UserPreferencesRepository.kt
@@ -82,6 +82,18 @@ interface UserPreferencesRepository {
     suspend fun setDarkMode(mode: String): Result<Unit>
 
     /**
+     * Get the app language preference as a Flow
+     * Returns "system" or a BCP 47 language tag (e.g., "en", "hi", "ja", "de")
+     */
+    fun getLanguage(): Flow<String>
+
+    /**
+     * Set the app language preference
+     * @param language "system" or a BCP 47 language tag (e.g., "en", "hi", "ja", "de")
+     */
+    suspend fun setLanguage(language: String): Result<Unit>
+
+    /**
      * Get the task list sort option as a Flow
      */
     fun getSortOption(): Flow<SortOption>

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/GetLanguageUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/GetLanguageUseCase.kt
@@ -1,0 +1,13 @@
+package com.shreyash.dotrack.domain.usecase.preferences
+
+import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetLanguageUseCase @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+    operator fun invoke(): Flow<String> {
+        return userPreferencesRepository.getLanguage()
+    }
+}

--- a/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/SetLanguageUseCase.kt
+++ b/domain/src/main/java/com/shreyash/dotrack/domain/usecase/preferences/SetLanguageUseCase.kt
@@ -1,0 +1,13 @@
+package com.shreyash.dotrack.domain.usecase.preferences
+
+import com.shreyash.dotrack.core.util.Result
+import com.shreyash.dotrack.domain.repository.UserPreferencesRepository
+import javax.inject.Inject
+
+class SetLanguageUseCase @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
+) {
+    suspend operator fun invoke(language: String): Result<Unit> {
+        return userPreferencesRepository.setLanguage(language)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 compose-activity = { group = "androidx.activity", name = "activity-compose", version.ref = "activity" }
 compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "compose-navigation" }
 compose-hilt-navigation = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "compose-hilt-navigation" }


### PR DESCRIPTION
## Summary
Adds Hindi (hi), Japanese (ja), and German (de) localization for issue #71, plus an in-app **language picker** so users can switch the app language without changing the device language.

## Changes

### Localization
- `app/src/main/res/values-hi/strings.xml` — all **121 strings** translated to Hindi
- `app/src/main/res/values-ja/strings.xml` — all **121 strings** translated to Japanese
- `app/src/main/res/values-de/strings.xml` — all **121 strings** translated to German
- 6 new strings (`language`, `language_system`, `language_english`, `language_hindi`, `language_japanese`, `language_german`) added in all 4 locales

### In-app language picker
- **Settings → Appearance** card: Dark Mode + Language dropdowns (Android-style rows with icons, check-mark on selected option)
- `AppLanguage` enum (system/en/hi/ja/de), persisted in DataStore (`language` key), `Get/SetLanguageUseCase`
- **Android 13+**: applies instantly via `LocaleManager.setApplicationLocales`
- **Android < 13**: `MainActivity.attachBaseContext` wraps the locale into the configuration; changing it recreates the activity
- `material-icons-extended` dependency added for `DarkMode`/`Language` icons

## Notes
- `app_name` and `reminder_channel_id` intentionally kept identical (IDs used at runtime)
- `date_time_format` / `date_format_widget` kept 1:1 — these strings are currently unused (date formatting is hardcoded `DateTimeFormatter`); true locale-aware date formats to be tracked separately
- Widget priority badges (H/M/L) kept as-is

## Verification
- `./gradlew assembleDebug` ✅
- `./gradlew test` ✅ (12/12 SettingsViewModelTest, incl. 2 new language tests)

Part of #71 — more languages can follow in the same pattern.