### PR TITLE
Fix auto wallpaper toggle, wallpaper sort, and home-list active-first ordering

### DIFF
--- a/app/src/main/java/com/shreyash/dotrack/core/util/TaskSorter.kt
+++ b/app/src/main/java/com/shreyash/dotrack/core/util/TaskSorter.kt
@@ -1,0 +1,19 @@
+package com.shreyash.dotrack.core.util
+
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
+import com.shreyash.dotrack.domain.model.Task
+import java.time.LocalDateTime
+
+object TaskSorter {
+
+    fun sort(tasks: List<Task>, option: SortOption, direction: SortDirection): List<Task> {
+        val sorted = when (option) {
+            SortOption.DUE_DATE -> tasks.sortedBy { it.dueDate ?: LocalDateTime.MAX }
+            SortOption.PRIORITY -> tasks.sortedByDescending { it.priority.value }
+            SortOption.CREATED_DATE -> tasks.sortedBy { it.createdAt }
+            SortOption.TITLE -> tasks.sortedBy { it.title.lowercase() }
+        }
+        return if (direction == SortDirection.DESCENDING) sorted.reversed() else sorted
+    }
+}

--- a/app/src/main/java/com/shreyash/dotrack/core/util/WallpaperGenerator.kt
+++ b/app/src/main/java/com/shreyash/dotrack/core/util/WallpaperGenerator.kt
@@ -13,11 +13,15 @@ import android.graphics.Shader
 import android.graphics.Typeface
 import androidx.core.graphics.ColorUtils
 import com.shreyash.dotrack.domain.model.Priority
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
 import com.shreyash.dotrack.domain.model.Task
 import com.shreyash.dotrack.domain.usecase.preferences.GetHighPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetLowPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetMediumPriorityColorUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetSecondaryWallpaperColorUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetSortDirectionUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetSortOptionUseCase
 import com.shreyash.dotrack.domain.usecase.preferences.GetWallpaperColorUseCase
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -35,7 +39,9 @@ class WallpaperGenerator @Inject constructor(
     private val getSecondaryWallpaperColorUseCase: GetSecondaryWallpaperColorUseCase,
     private val getHighPriorityColorUseCase: GetHighPriorityColorUseCase,
     private val getMediumPriorityColorUseCase: GetMediumPriorityColorUseCase,
-    private val getLowPriorityColorUseCase: GetLowPriorityColorUseCase
+    private val getLowPriorityColorUseCase: GetLowPriorityColorUseCase,
+    private val getSortOptionUseCase: GetSortOptionUseCase,
+    private val getSortDirectionUseCase: GetSortDirectionUseCase
 ) {
 
     private val wallpaperManager = WallpaperManager.getInstance(context)
@@ -58,6 +64,8 @@ class WallpaperGenerator @Inject constructor(
                 val highPriorityColorHex = getHighPriorityColorUseCase().first()
                 val mediumPriorityColorHex = getMediumPriorityColorUseCase().first()
                 val lowPriorityColorHex = getLowPriorityColorUseCase().first()
+                val sortOption = getSortOptionUseCase().first()
+                val sortDirection = getSortDirectionUseCase().first()
 
                 val bitmap = generateTaskListBitmap(
                     tasks,
@@ -65,7 +73,9 @@ class WallpaperGenerator @Inject constructor(
                     secondaryStartColorHex,
                     highPriorityColorHex,
                     mediumPriorityColorHex,
-                    lowPriorityColorHex
+                    lowPriorityColorHex,
+                    sortOption,
+                    sortDirection
                 )
                 try {
                     //only for system screen
@@ -93,7 +103,9 @@ class WallpaperGenerator @Inject constructor(
         endColorHex: String,
         highPriorityColorHex: String,
         mediumPriorityColorHex: String,
-        lowPriorityColorHex: String
+        lowPriorityColorHex: String,
+        sortOption: SortOption,
+        sortDirection: SortDirection
     ): Bitmap {
         val displayMetrics = context.resources.displayMetrics
         val width = displayMetrics.widthPixels
@@ -148,8 +160,11 @@ class WallpaperGenerator @Inject constructor(
 
         var y = topPadding
 
-        val pendingTasks = tasks.filter { !it.isCompleted }
-            .sortedByDescending { it.priority.value }
+        val pendingTasks = TaskSorter.sort(
+            tasks.filter { !it.isCompleted },
+            sortOption,
+            sortDirection
+        )
 
         if (pendingTasks.isEmpty()) {
             val noTasksText = "No pending tasks 🎉"

--- a/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/settings/SettingsViewModel.kt
@@ -173,7 +173,10 @@ class SettingsViewModel @Inject constructor(
      */
     fun setAutoWallpaperEnabled(enabled: Boolean) {
         viewModelScope.launch {
-            setAutoWallpaperEnabledUseCase(enabled)
+            val result = setAutoWallpaperEnabledUseCase(enabled)
+            if (enabled && result.isSuccess()) {
+                updateWallpaper()
+            }
         }
     }
 

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
@@ -105,7 +105,10 @@ class TasksViewModel @Inject constructor(
         when (result) {
             is Result.Success -> Result.Success(
                 filterTasks(
-                    sortTasks(result.data, option, direction),
+                    orderActiveFirstWhenViewingAll(
+                        sortTasks(result.data, option, direction),
+                        completedFilter
+                    ),
                     priorityFilter,
                     completedFilter
                 )
@@ -188,6 +191,16 @@ class TasksViewModel @Inject constructor(
 
     private fun sortTasks(tasks: List<Task>, option: SortOption, direction: SortDirection): List<Task> {
         return TaskSorter.sort(tasks, option, direction)
+    }
+
+    /**
+     * When viewing all tasks (no status filter), keep active (incomplete) tasks
+     * before completed ones, preserving the sort order within each group.
+     */
+    private fun orderActiveFirstWhenViewingAll(tasks: List<Task>, completedFilter: Boolean?): List<Task> {
+        if (completedFilter != null) return tasks
+        val (active, completed) = tasks.partition { !it.isCompleted }
+        return active + completed
     }
 
     private fun filterTasks(

--- a/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/shreyash/dotrack/ui/tasks/TasksViewModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.shreyash.dotrack.core.util.Result
+import com.shreyash.dotrack.core.util.TaskSorter
 import com.shreyash.dotrack.core.util.WallpaperGenerator
 import com.shreyash.dotrack.domain.ReminderScheduler
 import com.shreyash.dotrack.domain.model.Priority
@@ -40,7 +41,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -187,13 +187,7 @@ class TasksViewModel @Inject constructor(
     }
 
     private fun sortTasks(tasks: List<Task>, option: SortOption, direction: SortDirection): List<Task> {
-        val sorted = when (option) {
-            SortOption.DUE_DATE -> tasks.sortedBy { it.dueDate ?: LocalDateTime.MAX }
-            SortOption.PRIORITY -> tasks.sortedByDescending { it.priority.value }
-            SortOption.CREATED_DATE -> tasks.sortedBy { it.createdAt }
-            SortOption.TITLE -> tasks.sortedBy { it.title.lowercase() }
-        }
-        return if (direction == SortDirection.DESCENDING) sorted.reversed() else sorted
+        return TaskSorter.sort(tasks, option, direction)
     }
 
     private fun filterTasks(

--- a/app/src/test/java/com/shreyash/dotrack/core/util/TaskSorterTest.kt
+++ b/app/src/test/java/com/shreyash/dotrack/core/util/TaskSorterTest.kt
@@ -1,0 +1,114 @@
+package com.shreyash.dotrack.core.util
+
+import com.shreyash.dotrack.domain.model.Priority
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
+import com.shreyash.dotrack.domain.model.Task
+import java.time.LocalDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TaskSorterTest {
+
+    private val now = LocalDateTime.of(2026, 8, 6, 12, 0)
+
+    private fun task(
+        id: String,
+        title: String,
+        priority: Priority,
+        dueDate: LocalDateTime?,
+        createdAt: LocalDateTime,
+        completed: Boolean = false,
+    ) = Task(
+        id = id,
+        title = title,
+        description = "",
+        isCompleted = completed,
+        dueDate = dueDate,
+        priority = priority,
+        reminderEnabled = false,
+        createdAt = createdAt,
+        updatedAt = createdAt,
+        categoryId = null
+    )
+
+    // t1: due today, created 3 days ago, LOW
+    private val t1 = task("t1", "Alpha", Priority.LOW, now, now.minusDays(3))
+    // t2: due tomorrow, created in 2 days, HIGH
+    private val t2 = task("t2", "Beta", Priority.HIGH, now.plusDays(1), now.plusDays(2))
+    // t3: no due date, created now, MEDIUM
+    private val t3 = task("t3", "Gamma", Priority.MEDIUM, null, now)
+    // t4: due day after tomorrow, created tomorrow, LOW
+    private val t4 = task("t4", "apple first", Priority.LOW, now.plusDays(2), now.plusDays(1))
+
+    private fun ids(tasks: List<Task>) = tasks.map { it.id }
+
+    @Test
+    fun `sorts by due date ascending with no-due tasks last`() {
+        val result = TaskSorter.sort(
+            listOf(t3, t1, t2, t4),
+            SortOption.DUE_DATE,
+            SortDirection.ASCENDING
+        )
+        assertEquals(listOf("t1", "t2", "t4", "t3"), ids(result))
+    }
+
+    @Test
+    fun `sorts by due date descending with no-due tasks first`() {
+        val result = TaskSorter.sort(
+            listOf(t3, t4, t2, t1),
+            SortOption.DUE_DATE,
+            SortDirection.DESCENDING
+        )
+        assertEquals(listOf("t3", "t4", "t2", "t1"), ids(result))
+    }
+
+    @Test
+    fun `sorts by priority descending`() {
+        val result = TaskSorter.sort(
+            listOf(t1, t3, t2),
+            SortOption.PRIORITY,
+            SortDirection.DESCENDING
+        )
+        assertEquals(listOf("t1", "t3", "t2"), ids(result))
+    }
+
+    @Test
+    fun `sorts by priority ascending`() {
+        val result = TaskSorter.sort(
+            listOf(t1, t3, t2),
+            SortOption.PRIORITY,
+            SortDirection.ASCENDING
+        )
+        assertEquals(listOf("t2", "t3", "t1"), ids(result))
+    }
+
+    @Test
+    fun `sorts by created date ascending`() {
+        val result = TaskSorter.sort(
+            listOf(t4, t1, t3, t2),
+            SortOption.CREATED_DATE,
+            SortDirection.ASCENDING
+        )
+        assertEquals(listOf("t1", "t3", "t4", "t2"), ids(result))
+    }
+
+    @Test
+    fun `sorts by title case-insensitive ascending`() {
+        val upper = task("u", "Alpha", Priority.LOW, null, now)
+        val lower = task("a", "beta", Priority.LOW, null, now)
+        val result = TaskSorter.sort(
+            listOf(lower, upper),
+            SortOption.TITLE,
+            SortDirection.ASCENDING
+        )
+        assertEquals(listOf("u", "a"), ids(result))
+    }
+
+    @Test
+    fun `sort does not mutate the input list`() {
+        val original = listOf(t1, t2, t4)
+        TaskSorter.sort(original, SortOption.TITLE, SortDirection.ASCENDING)
+        assertEquals(original, listOf(t1, t2, t4))
+    }
+}

--- a/app/src/test/java/com/shreyash/dotrack/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/shreyash/dotrack/ui/settings/SettingsViewModelTest.kt
@@ -137,7 +137,10 @@ class SettingsViewModelTest {
     @Test
     fun `test auto wallpaper toggle functionality`() = runTest {
         // Given
+        val tasks = listOf(mockk<Task>())
         coEvery { setAutoWallpaperEnabledUseCase(any()) } returns Result.Success(Unit)
+        every { getAutoWallpaperEnabledUseCase() } returns flowOf(true)
+        every { getTasksUseCase() } returns flowOf(Result.Success(tasks))
 
         // When
         viewModel.setAutoWallpaperEnabled(true)
@@ -145,6 +148,36 @@ class SettingsViewModelTest {
 
         // Then
         coVerify { setAutoWallpaperEnabledUseCase(true) }
+        coVerify { wallpaperGenerator.generateAndSetWallpaper(tasks) }
+    }
+
+    @Test
+    fun `test disabling auto wallpaper does not update wallpaper`() = runTest {
+        // Given
+        coEvery { setAutoWallpaperEnabledUseCase(any()) } returns Result.Success(Unit)
+        every { getAutoWallpaperEnabledUseCase() } returns flowOf(false)
+        every { getTasksUseCase() } returns flowOf(Result.Success(emptyList<Task>()))
+
+        // When
+        viewModel.setAutoWallpaperEnabled(false)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        coVerify { setAutoWallpaperEnabledUseCase(false) }
+        coVerify(exactly = 0) { wallpaperGenerator.generateAndSetWallpaper(any()) }
+    }
+
+    @Test
+    fun `test enabling auto wallpaper does not update wallpaper when write fails`() = runTest {
+        // Given
+        coEvery { setAutoWallpaperEnabledUseCase(any()) } returns Result.Error(Exception("Failed"))
+
+        // When
+        viewModel.setAutoWallpaperEnabled(true)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        coVerify(exactly = 0) { wallpaperGenerator.generateAndSetWallpaper(any()) }
     }
 
 

--- a/app/src/test/java/com/shreyash/dotrack/ui/tasks/TasksViewModelOrderingTest.kt
+++ b/app/src/test/java/com/shreyash/dotrack/ui/tasks/TasksViewModelOrderingTest.kt
@@ -1,0 +1,201 @@
+package com.shreyash.dotrack.ui.tasks
+
+import android.content.Context
+import com.shreyash.dotrack.core.util.Result
+import com.shreyash.dotrack.core.util.WallpaperGenerator
+import com.shreyash.dotrack.domain.ReminderScheduler
+import com.shreyash.dotrack.domain.model.Priority
+import com.shreyash.dotrack.domain.model.SortDirection
+import com.shreyash.dotrack.domain.model.SortOption
+import com.shreyash.dotrack.domain.model.Task
+import com.shreyash.dotrack.domain.usecase.preferences.GetAutoWallpaperEnabledUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetSortDirectionUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.GetSortOptionUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.SetSortDirectionUseCase
+import com.shreyash.dotrack.domain.usecase.preferences.SetSortOptionUseCase
+import com.shreyash.dotrack.domain.usecase.task.CompleteTaskUseCase
+import com.shreyash.dotrack.domain.usecase.task.DeleteTaskUseCase
+import com.shreyash.dotrack.domain.usecase.task.DeleteTasksUseCase
+import com.shreyash.dotrack.domain.usecase.task.DisableReminderUseCase
+import com.shreyash.dotrack.domain.usecase.task.GetTasksUseCase
+import com.shreyash.dotrack.domain.usecase.task.UncompleteTaskUseCase
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TasksViewModelOrderingTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var context: Context
+    private lateinit var tasksFlow: MutableStateFlow<Result<List<Task>>>
+    private lateinit var getTasksUseCase: GetTasksUseCase
+    private lateinit var completeTaskUseCase: CompleteTaskUseCase
+    private lateinit var uncompleteTaskUseCase: UncompleteTaskUseCase
+    private lateinit var wallpaperGenerator: WallpaperGenerator
+    private lateinit var deleteTaskUseCase: DeleteTaskUseCase
+    private lateinit var deleteTasksUseCase: DeleteTasksUseCase
+    private lateinit var getAutoWallpaperEnabledUseCase: GetAutoWallpaperEnabledUseCase
+    private lateinit var disableReminderUseCase: DisableReminderUseCase
+    private lateinit var reminderScheduler: ReminderScheduler
+    private lateinit var getSortOptionUseCase: GetSortOptionUseCase
+    private lateinit var setSortOptionUseCase: SetSortOptionUseCase
+    private lateinit var getSortDirectionUseCase: GetSortDirectionUseCase
+    private lateinit var setSortDirectionUseCase: SetSortDirectionUseCase
+
+    private lateinit var viewModel: TasksViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testDispatcher.scheduler))
+        context = mockk(relaxed = true)
+        tasksFlow = MutableStateFlow(Result.Success(emptyList<Task>()))
+        getTasksUseCase = mockk()
+        completeTaskUseCase = mockk(relaxed = true)
+        uncompleteTaskUseCase = mockk(relaxed = true)
+        wallpaperGenerator = mockk(relaxed = true)
+        deleteTaskUseCase = mockk(relaxed = true)
+        deleteTasksUseCase = mockk(relaxed = true)
+        getAutoWallpaperEnabledUseCase = mockk(relaxed = true)
+        disableReminderUseCase = mockk(relaxed = true)
+        reminderScheduler = mockk(relaxed = true)
+        getSortOptionUseCase = mockk()
+        setSortOptionUseCase = mockk(relaxed = true)
+        getSortDirectionUseCase = mockk()
+        setSortDirectionUseCase = mockk(relaxed = true)
+
+        every { getSortOptionUseCase() } returns flowOf(SortOption.DUE_DATE)
+        every { getSortDirectionUseCase() } returns flowOf(SortDirection.ASCENDING)
+        every { getTasksUseCase() } returns tasksFlow
+
+        viewModel = TasksViewModel(
+            context = context,
+            getTasksUseCase = getTasksUseCase,
+            completeTaskUseCase = completeTaskUseCase,
+            uncompleteTaskUseCase = uncompleteTaskUseCase,
+            wallpaperGenerator = wallpaperGenerator,
+            deleteTaskUseCase = deleteTaskUseCase,
+            deleteTasksUseCase = deleteTasksUseCase,
+            getAutoWallpaperEnabledUseCase = getAutoWallpaperEnabledUseCase,
+            disableReminderUseCase = disableReminderUseCase,
+            reminderScheduler = reminderScheduler,
+            getSortOptionUseCase = getSortOptionUseCase,
+            setSortOptionUseCase = setSortOptionUseCase,
+            getSortDirectionUseCase = getSortDirectionUseCase,
+            setSortDirectionUseCase = setSortDirectionUseCase
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        clearAllMocks()
+    }
+
+    private val now = LocalDateTime.of(2026, 8, 6, 12, 0)
+
+    private fun task(
+        id: String,
+        priority: Priority,
+        dueDate: LocalDateTime?,
+        completed: Boolean = false,
+    ) = Task(
+        id = id,
+        title = id,
+        description = "",
+        isCompleted = completed,
+        dueDate = dueDate,
+        priority = priority,
+        reminderEnabled = false,
+        createdAt = now,
+        updatedAt = now,
+        categoryId = null
+    )
+
+    private fun stubTasks(tasks: List<Task>) {
+        tasksFlow.value = Result.Success(tasks)
+    }
+
+    /**
+     * Subscribes to [TasksViewModel.sortedTasks] (WhileSubscribed), advances the
+     * main test dispatcher until the combine emits, then returns the sorted task ids.
+     */
+    private suspend fun TestScope.sortedIds(
+        statusFilter: Boolean? = null,
+        priorityFilter: Priority? = null,
+    ): List<String> {
+        viewModel.setFilterStatus(statusFilter)
+        viewModel.setFilterPriority(priorityFilter)
+        val result = viewModel.sortedTasks.filterIsInstance<Result.Success<List<Task>>>().first()
+        return result.data.map { it.id }
+    }
+
+    @Test
+    fun `viewing all shows active tasks before completed within sort`() = runTest {
+        // Completed task has the earliest due date - still must appear after all active tasks
+        val activeLater = task("active-later", Priority.LOW, now.plusDays(5))
+        val completedEarly = task("completed-early", Priority.HIGH, now.plusDays(1), completed = true)
+        val activeSoon = task("active-soon", Priority.MEDIUM, now.plusDays(2))
+        stubTasks(listOf(completedEarly, activeLater, activeSoon))
+
+        assertEquals(listOf("active-soon", "active-later", "completed-early"), sortedIds())
+    }
+
+    @Test
+    fun `viewing all keeps each group sorted by due date descending`() = runTest {
+        val activeSoon = task("active-soon", Priority.MEDIUM, now.plusDays(2))
+        val activeLater = task("active-later", Priority.LOW, now.plusDays(5))
+        val completedEarly = task("completed-early", Priority.HIGH, now.plusDays(1), completed = true)
+        stubTasks(listOf(completedEarly, activeLater, activeSoon))
+
+        viewModel.setSortDirection(SortDirection.DESCENDING)
+
+        assertEquals(listOf("active-later", "active-soon", "completed-early"), sortedIds())
+    }
+
+    @Test
+    fun `active filter shows only incomplete tasks`() = runTest {
+        val active = task("active", Priority.MEDIUM, now)
+        val completed = task("completed", Priority.LOW, now, completed = true)
+        stubTasks(listOf(completed, active))
+
+        assertEquals(listOf("active"), sortedIds(statusFilter = false))
+    }
+
+    @Test
+    fun `completed filter shows only completed tasks`() = runTest {
+        val active = task("active", Priority.MEDIUM, now)
+        val completed = task("completed", Priority.LOW, now, completed = true)
+        stubTasks(listOf(completed, active))
+
+        assertEquals(listOf("completed"), sortedIds(statusFilter = true))
+    }
+
+    @Test
+    fun `priority filter composes with active-first ordering`() = runTest {
+        val lowActive = task("low-active", Priority.LOW, now.plusDays(1))
+        val highCompleted = task("high-completed", Priority.HIGH, now.plusDays(1), completed = true)
+        val highActive = task("high-active", Priority.HIGH, now.plusDays(2))
+        stubTasks(listOf(lowActive, highCompleted, highActive))
+
+        assertEquals(listOf("high-active", "high-completed"), sortedIds(priorityFilter = Priority.HIGH))
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes in the wallpaper/list flow:

### 1. Auto Wallpaper Updates toggle now applies the wallpaper (#94)
- `SettingsViewModel.setAutoWallpaperEnabled()` previously only persisted the flag to DataStore — toggling did nothing visible.
- Now, after a successful write with `enabled == true`, it calls `updateWallpaper()` to immediately generate and set the wallpaper from current pending tasks.

### 2. Wallpaper task cards follow the user's selected sort (#93)
- `WallpaperGenerator` hardcoded cards to HIGH → MEDIUM → LOW priority.
- It now reads the saved `SortOption`/`SortDirection` from DataStore and orders the drawn pending tasks the same way as the tasks list.
- Sorting logic extracted to shared `core/util/TaskSorter.kt`, used by both `TasksViewModel` (list) and `WallpaperGenerator` (wallpaper). Completed tasks are still excluded from the wallpaper.

### 3. Home list: active tasks first when status filter is "All" (#96)
- With status filter = **All**, incomplete (active) tasks now always render above completed tasks, with the selected sort option/direction applied within each group.
- Active/Completed filters and priority filter composition are unchanged.

## Tests
- `TaskSorterTest`: due-date (asc/desc, null-due handling), priority asc/desc, created-date, title case-insensitive, immutability.
- `SettingsViewModelTest`: enable → generates wallpaper; disable → no update; failed write → no update.
- `TasksViewModelOrderingTest`: All → active-first ordering; descending sort per group; Active filter; Completed filter; priority filter composition.

Verified: `./gradlew testDebugUnitTest assembleDebug` passes.

Closes #93, #94, #96