### PR TITLE
Fix release-only UI freeze: keep DataStore proto classes for R8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,8 +56,8 @@ android {
         }
         release {
             isDebuggable = false
-            isMinifyEnabled = false
-            isShrinkResources = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -9,6 +9,9 @@
 #   - Kotlin Coroutines
 # Everything else is shrunk and obfuscated by R8 full mode.
 
+# BISECT-TEST: no obfuscation
+-dontobfuscate
+
 # ================================
 # Stack traces
 # ================================

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -9,8 +9,8 @@
 #   - Kotlin Coroutines
 # Everything else is shrunk and obfuscated by R8 full mode.
 
-# BISECT-TEST: no obfuscation
--dontobfuscate
+# BISECT-TEST: no optimization
+-dontoptimize
 
 # ================================
 # Stack traces

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -9,8 +9,10 @@
 #   - Kotlin Coroutines
 # Everything else is shrunk and obfuscated by R8 full mode.
 
-# BISECT-TEST: no optimization
--dontoptimize
+# DataStore Preferences vendored-protobuf generates reflective field access
+# (e.g. MessageSchema looks up "preferences_" on the proto class). R8 strips
+# those private fields unless the generated classes are kept.
+-keep class androidx.datastore.preferences.PreferencesProto$** { *; }
 
 # ================================
 # Stack traces


### PR DESCRIPTION
## Summary
Fixes the release-build freeze/ANR (and startup crash) caused by R8 stripping fields that AndroidX DataStore's vendored protobuf accesses reflectively.

- **Reverts** the temporary `isMinifyEnabled = false / isShrinkResources = false` workaround in `app/build.gradle.kts` — minification stays **on**.
- **Adds** keep rule in `app/proguard-rules.pro`:
  ```
  -keep class androidx.datastore.preferences.PreferencesProto$** { *; }
  ```

## Root cause
`androidx.datastore.preferences.protobuf.MessageSchema` finds the generated proto class's private backing field `preferences_` **by name at runtime**. R8's shrinker deleted/renamed that field, so the first DataStore `Preferences` read threw:
```
java.lang.RuntimeException: Field preferences_ for <obf> not found.
    at androidx.datastore.preferences.protobuf.MessageSchema...
```
Debug builds were never minified → always worked; the release build froze/crashed.

## Verification (on physical device, release APKs)
| Config | Result |
|---|---|
| minify+shrink, `-dontobfuscate` | works |
| minify+shrink, obfuscate on, `-dontoptimize` | crashes with field-not-found |
| full minify + keep rule (this PR) | **works** |

Verified: app boots, navigation responsive, Auto Wallpaper Updates toggle persists and regenerates wallpaper, no crash.

## Issue
Closes #97 (full analysis + stack trace commented there).